### PR TITLE
[Feat] #47 DB 개인정보 목록 API 연동

### DIFF
--- a/src/features/db-pii/api/db-pii-api.ts
+++ b/src/features/db-pii/api/db-pii-api.ts
@@ -1,0 +1,112 @@
+import { API_BASE_URL, getApiErrorMessage } from "@/shared/lib/api";
+import { fetchWithAuth } from "@/features/auth/model/api-client";
+import type {
+  DbPiiConnection,
+  DbPiiTable,
+  DbPiiColumnsResult,
+  GetDbPiiColumnsParams,
+  ApiResponse,
+} from "./types";
+
+const BASE = `${API_BASE_URL}/api/db-pii`;
+
+function errorMessage(
+  data: { message?: string } | null,
+  status: number,
+): string {
+  return data?.message ?? `요청 실패 (${status})`;
+}
+
+function toErrorResponse<T>(error: unknown): ApiResponse<T> {
+  return {
+    success: false,
+    code: "",
+    message: getApiErrorMessage(error),
+    result: null,
+    timestamp: "",
+  };
+}
+
+/** 5-1. DB PII 커넥션 목록 조회 (필터용) */
+export async function getDbPiiConnections(): Promise<
+  ApiResponse<DbPiiConnection[]>
+> {
+  try {
+    const res = await fetchWithAuth(`${BASE}/connections`);
+    const data = (await res
+      .json()
+      .catch(() => ({}))) as ApiResponse<DbPiiConnection[]>;
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<DbPiiConnection[]>(e);
+  }
+}
+
+/** 5-2. DB PII 테이블 목록 조회 */
+export async function getDbPiiTables(
+  connectionId: number,
+): Promise<ApiResponse<DbPiiTable[]>> {
+  try {
+    const res = await fetchWithAuth(
+      `${BASE}/connections/${connectionId}/tables`,
+    );
+    const data = (await res
+      .json()
+      .catch(() => ({}))) as ApiResponse<DbPiiTable[]>;
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<DbPiiTable[]>(e);
+  }
+}
+
+/** 5-3. DB PII 컬럼 목록·통계 조회 */
+export async function getDbPiiColumns(
+  params?: GetDbPiiColumnsParams,
+): Promise<ApiResponse<DbPiiColumnsResult>> {
+  try {
+    const search = new URLSearchParams();
+    if (params?.connectionId != null)
+      search.set("connectionId", String(params.connectionId));
+    if (params?.tableId != null) search.set("tableId", String(params.tableId));
+    if (params?.piiType != null) search.set("piiType", params.piiType);
+    if (params?.encrypted != null)
+      search.set("encrypted", String(params.encrypted));
+    if (params?.riskLevel != null) search.set("riskLevel", params.riskLevel);
+    if (params?.keyword != null) search.set("keyword", params.keyword);
+    if (params?.page != null) search.set("page", String(params.page));
+    if (params?.size != null) search.set("size", String(params.size));
+    const qs = search.toString();
+    const url = qs ? `${BASE}/columns?${qs}` : `${BASE}/columns`;
+    const res = await fetchWithAuth(url);
+    const data = (await res
+      .json()
+      .catch(() => ({}))) as ApiResponse<DbPiiColumnsResult>;
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<DbPiiColumnsResult>(e);
+  }
+}

--- a/src/features/db-pii/api/index.ts
+++ b/src/features/db-pii/api/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./db-pii-api";

--- a/src/features/db-pii/api/types.ts
+++ b/src/features/db-pii/api/types.ts
@@ -1,0 +1,71 @@
+/** 5-1. DB PII 커넥션 한 건 */
+export interface DbPiiConnection {
+  id: number;
+  connectionName: string;
+  dbmsTypeName: string;
+}
+
+/** 5-2. DB PII 테이블 한 건 */
+export interface DbPiiTable {
+  id: number;
+  tableName: string;
+}
+
+/** 5-3. PII 컬럼 한 건 */
+export interface DbPiiColumn {
+  id: number;
+  connectionName: string;
+  dbmsTypeName: string;
+  tableName: string;
+  columnName: string;
+  piiTypeName: string;
+  piiTypeCode: string;
+  encrypted: boolean;
+  riskLevel: "HIGH" | "MEDIUM" | "LOW";
+  lastScannedAt: string;
+}
+
+/** 5-3. 컬럼 목록 응답 stats */
+export interface DbPiiColumnsStats {
+  totalItems: number;
+  highRiskItems: number;
+  encryptionRate: number;
+  totalRecords: number;
+}
+
+/** 5-3. Slice 페이지 content */
+export interface DbPiiColumnsContent {
+  content: DbPiiColumn[];
+  pageable: { pageNumber: number; pageSize: number };
+  first: boolean;
+  last: boolean;
+  hasNext: boolean;
+  numberOfElements: number;
+}
+
+/** 5-3. 컬럼 목록 응답 result */
+export interface DbPiiColumnsResult {
+  stats: DbPiiColumnsStats;
+  content: DbPiiColumnsContent;
+}
+
+/** 5-3. 쿼리 파라미터 */
+export interface GetDbPiiColumnsParams {
+  connectionId?: number;
+  tableId?: number;
+  piiType?: string;
+  encrypted?: boolean;
+  riskLevel?: "HIGH" | "MEDIUM" | "LOW";
+  keyword?: string;
+  page?: number;
+  size?: number;
+}
+
+/** API 공통 응답 래퍼 */
+export interface ApiResponse<T> {
+  success: boolean;
+  code: string;
+  message: string;
+  result: T | null;
+  timestamp: string;
+}

--- a/src/features/db-pii/index.ts
+++ b/src/features/db-pii/index.ts
@@ -1,0 +1,1 @@
+export * from "./api";

--- a/src/views/db-privacy-list/lib/format.ts
+++ b/src/views/db-privacy-list/lib/format.ts
@@ -1,0 +1,16 @@
+/** API lastScannedAt ISO 문자열 → 스캔일시 표시 (YYYY.MM.DD HH:mm) */
+export function formatScanDateTime(isoString: string): string {
+  if (!isoString || typeof isoString !== "string") return "";
+  try {
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) return isoString;
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, "0");
+    const d = String(date.getDate()).padStart(2, "0");
+    const h = String(date.getHours()).padStart(2, "0");
+    const min = String(date.getMinutes()).padStart(2, "0");
+    return `${y}.${m}.${d} ${h}:${min}`;
+  } catch {
+    return isoString;
+  }
+}

--- a/src/views/db-privacy-list/ui/FilterSection.tsx
+++ b/src/views/db-privacy-list/ui/FilterSection.tsx
@@ -13,6 +13,7 @@ interface FilterSectionProps {
   onSearchQueryChange: (value: string) => void;
   onSearch: () => void;
   onReset: () => void;
+  searchPlaceholder?: string;
   connectionOptions: Option[];
   selectedConnection: string;
   onConnectionChange: (value: string) => void;
@@ -46,6 +47,7 @@ export default function FilterSection({
   onSearchQueryChange,
   onSearch,
   onReset,
+  searchPlaceholder = "파일명 또는 경로 검색...",
   connectionOptions,
   selectedConnection,
   onConnectionChange,
@@ -73,7 +75,7 @@ export default function FilterSection({
             type="text"
             value={searchQuery}
             onChange={(e) => onSearchQueryChange(e.target.value)}
-            placeholder="파일명 또는 경로 검색..."
+            placeholder={searchPlaceholder}
             colorScheme="main"
             className="flex-1"
           />

--- a/src/views/db-privacy-list/ui/Page.tsx
+++ b/src/views/db-privacy-list/ui/Page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
 import { Table as TableIcon, AlertTriangle, Lock, Database } from "lucide-react";
 import {
   StatCard,
@@ -9,8 +10,28 @@ import {
 import type { TableColumn } from "@/shared/ui";
 import { cn } from "@/shared/lib/utils";
 import FilterSection from "./FilterSection";
+import {
+  getDbPiiConnections,
+  getDbPiiTables,
+  getDbPiiColumns,
+} from "@/features/db-pii";
+import type { DbPiiConnection, DbPiiTable, DbPiiColumn } from "@/features/db-pii";
+import { formatScanDateTime } from "../lib/format";
 
-interface PrivacyItem extends Record<string, unknown> {
+/** API riskLevel → UI 한글 */
+const riskLevelToLabel: Record<string, "높음" | "중간" | "낮음"> = {
+  HIGH: "높음",
+  MEDIUM: "중간",
+  LOW: "낮음",
+};
+
+/** API encrypted → UI 암호화 라벨 */
+function encryptionLabel(encrypted: boolean): "보안필요" | "양호" {
+  return encrypted ? "양호" : "보안필요";
+}
+
+/** 테이블 행용 (API 컬럼 → UI) */
+interface TableRow extends Record<string, unknown> {
   id: string;
   dbConnection: string;
   table: string;
@@ -21,45 +42,91 @@ interface PrivacyItem extends Record<string, unknown> {
   scanDateTime: string;
 }
 
+function columnToRow(c: DbPiiColumn): TableRow {
+  return {
+    id: String(c.id),
+    dbConnection: c.connectionName,
+    table: c.tableName,
+    column: c.columnName,
+    type: c.piiTypeName,
+    encryption: encryptionLabel(c.encrypted),
+    riskLevel: riskLevelToLabel[c.riskLevel] ?? "낮음",
+    scanDateTime: formatScanDateTime(c.lastScannedAt),
+  };
+}
 
-const generatePrivacyItems = (): PrivacyItem[] => {
-  const items: PrivacyItem[] = [];
-  const connections = [
-    "운영 DB (PostgreSQL)",
-    "레거시 시스템 (Oracle)",
-    "고객 DB (MySQL)",
-  ];
-  const tables = ["users", "payments", "customer_backup"];
-  const columns = [
-    "full_name",
-    "phone_number",
-    "ssn",
-    "mobile",
-    "email",
-    "address",
-  ];
-  const types = ["이름", "전화번호", "주민등록번호", "이메일", "주소"];
-  const encryptions: Array<"보안필요" | "양호"> = ["보안필요", "양호"];
-  const riskLevels: Array<"높음" | "중간" | "낮음"> = ["높음", "중간", "낮음"];
+/** PII 유형 필터 옵션 (API 코드 ↔ 한글) */
+const PII_TYPE_OPTIONS = [
+  { value: "all", label: "모든 유형" },
+  { value: "NM", label: "이름" },
+  { value: "EM", label: "이메일" },
+  { value: "PH", label: "전화번호" },
+  { value: "RRN", label: "주민등록번호" },
+  { value: "ADD", label: "주소" },
+  { value: "IP", label: "IP" },
+  { value: "ACN", label: "계좌번호" },
+  { value: "PP", label: "기타" },
+];
 
-  for (let i = 1; i <= 200; i++) {
-    items.push({
-      id: i.toString(),
-      dbConnection: connections[(i - 1) % connections.length],
-      table: tables[(i - 1) % tables.length],
-      column: columns[(i - 1) % columns.length],
-      type: types[(i - 1) % types.length],
-      encryption: encryptions[(i - 1) % encryptions.length],
-      riskLevel: riskLevels[(i - 1) % riskLevels.length],
-      scanDateTime: `01/${18 + (i % 2)} ${String(10 + (i % 12)).padStart(2, "0")}:${String((i * 10) % 60).padStart(2, "0")}`,
-    });
-  }
-  return items;
+const PAGE_SIZE = 20;
+
+/** 테스트용 샘플 행 (URL에 ?mock=1 일 때 API 빈 응답 시 표시) */
+const SAMPLE_ROWS: TableRow[] = [
+  {
+    id: "1",
+    dbConnection: "운영 DB (PostgreSQL)",
+    table: "users",
+    column: "email",
+    type: "이메일",
+    encryption: "보안필요",
+    riskLevel: "높음",
+    scanDateTime: "2026.01.29 02:00",
+  },
+  {
+    id: "2",
+    dbConnection: "운영 DB (PostgreSQL)",
+    table: "customers",
+    column: "phone",
+    type: "전화번호",
+    encryption: "양호",
+    riskLevel: "낮음",
+    scanDateTime: "2026.01.29 02:00",
+  },
+  {
+    id: "3",
+    dbConnection: "운영 DB (PostgreSQL)",
+    table: "orders",
+    column: "delivery_address",
+    type: "주소",
+    encryption: "보안필요",
+    riskLevel: "중간",
+    scanDateTime: "2026.01.28 14:30",
+  },
+];
+
+const SAMPLE_STATS = {
+  totalItems: 42,
+  highRiskItems: 15,
+  encryptionRate: 85.5,
+  totalRecords: 125_000,
 };
 
 export default function DbPrivacyListPage() {
-  const [privacyItems] = useState<PrivacyItem[]>(generatePrivacyItems());
-  
+  const searchParams = useSearchParams();
+  const useMock = searchParams.get("mock") === "1";
+
+  const [connections, setConnections] = useState<DbPiiConnection[]>([]);
+  const [tables, setTables] = useState<DbPiiTable[]>([]);
+  const [rows, setRows] = useState<TableRow[]>([]);
+  const [stats, setStats] = useState<{
+    totalItems: number;
+    highRiskItems: number;
+    encryptionRate: number;
+    totalRecords: number;
+  } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
   const [searchQuery, setSearchQuery] = useState("");
   const [appliedSearchQuery, setAppliedSearchQuery] = useState("");
   const [selectedConnection, setSelectedConnection] = useState("all");
@@ -67,98 +134,154 @@ export default function DbPrivacyListPage() {
   const [selectedType, setSelectedType] = useState("all");
   const [selectedEncryption, setSelectedEncryption] = useState("all");
   const [selectedRiskLevel, setSelectedRiskLevel] = useState("all");
+  const [page, setPage] = useState(0);
+  const [hasNext, setHasNext] = useState(false);
 
-  const connectionOptions = useMemo(() => {
-    const unique = Array.from(
-      new Set(privacyItems.map((i) => i.dbConnection).filter(Boolean)),
-    );
-    return [
-      { value: "all", label: "모든 커넥션" },
-      ...unique.map((v) => ({ value: v, label: v })),
-    ];
-  }, [privacyItems]);
+  const connectionOptions = [
+    { value: "all", label: "모든 커넥션" },
+    ...connections.map((c) => ({
+      value: String(c.id),
+      label: `${c.connectionName} (${c.dbmsTypeName})`,
+    })),
+  ];
 
-  const tableOptions = useMemo(() => {
-    const unique = Array.from(
-      new Set(privacyItems.map((i) => i.table).filter(Boolean)),
-    );
-    return [
-      { value: "all", label: "모든 테이블" },
-      ...unique.map((v) => ({ value: v, label: v })),
-    ];
-  }, [privacyItems]);
+  const tableOptions = [
+    { value: "all", label: "모든 테이블" },
+    ...tables.map((t) => ({ value: String(t.id), label: t.tableName })),
+  ];
 
-  const typeOptions = useMemo(() => {
-    const unique = Array.from(
-      new Set(privacyItems.map((i) => i.type).filter(Boolean)),
-    );
-    return [
-      { value: "all", label: "모든 유형" },
-      ...unique.map((v) => ({ value: v, label: v })),
-    ];
-  }, [privacyItems]);
+  const loadConnections = useCallback(async () => {
+    const res = await getDbPiiConnections();
+    if (res.success && res.result) {
+      setConnections(res.result);
+      setError(null);
+    } else if (!res.success) {
+      setError(res.message ?? "커넥션 목록을 불러오지 못했습니다.");
+    }
+  }, []);
 
-  const filteredItems = useMemo(() => {
-    return privacyItems.filter((item) => {
-      if (appliedSearchQuery) {
-        const query = appliedSearchQuery.toLowerCase();
-        if (
-          !item.table.toLowerCase().includes(query) &&
-          !item.column.toLowerCase().includes(query) &&
-          !item.dbConnection.toLowerCase().includes(query)
-        ) {
-          return false;
+  const loadTables = useCallback(async (connectionId: number) => {
+    const res = await getDbPiiTables(connectionId);
+    if (res.success && res.result) setTables(res.result);
+    else setTables([]);
+  }, []);
+
+  const loadColumns = useCallback(
+    async (pageNum: number, append: boolean) => {
+      const connectionId =
+        selectedConnection === "all" ? undefined : Number(selectedConnection);
+      const tableId =
+        selectedTable === "all" ? undefined : Number(selectedTable);
+      const piiType = selectedType === "all" ? undefined : selectedType;
+      const encrypted =
+        selectedEncryption === "all"
+          ? undefined
+          : selectedEncryption === "good";
+      const riskLevel =
+        selectedRiskLevel === "all"
+          ? undefined
+          : (selectedRiskLevel.toUpperCase() as "HIGH" | "MEDIUM" | "LOW");
+      const res = await getDbPiiColumns({
+        connectionId,
+        tableId,
+        piiType,
+        encrypted,
+        riskLevel,
+        keyword: appliedSearchQuery || undefined,
+        page: pageNum,
+        size: PAGE_SIZE,
+      });
+      if (!res.success) {
+        if (useMock && !append) {
+          setError(null);
+          setRows(SAMPLE_ROWS);
+          setStats(SAMPLE_STATS);
+          setHasNext(false);
+        } else {
+          setError(res.message ?? "컬럼 목록을 불러오지 못했습니다.");
+          if (!append) setRows([]);
+          setHasNext(false);
+        }
+        return;
+      }
+      setError(null);
+      if (res.result) {
+        const rawContent = res.result.content;
+        const contentArray = Array.isArray(rawContent)
+          ? rawContent
+          : (rawContent as { content?: DbPiiColumn[] } | undefined)?.content;
+        const list = Array.isArray(contentArray)
+          ? contentArray.map(columnToRow)
+          : [];
+        if (list.length > 0) {
+          if (append) setRows((prev) => [...prev, ...list]);
+          else setRows(list);
+          setStats(res.result.stats ?? null);
+          const slice = rawContent as { hasNext?: boolean } | undefined;
+          setHasNext(Boolean(slice?.hasNext));
+        } else if (useMock && !append) {
+          setRows(SAMPLE_ROWS);
+          setStats(SAMPLE_STATS);
+          setHasNext(false);
+        } else {
+          if (!append) setRows([]);
+          setStats(res.result.stats ?? null);
+          const slice = rawContent as { hasNext?: boolean } | undefined;
+          setHasNext(Boolean(slice?.hasNext));
+        }
+      } else {
+        if (useMock && !append) {
+          setRows(SAMPLE_ROWS);
+          setStats(SAMPLE_STATS);
+          setHasNext(false);
+        } else {
+          if (!append) setRows([]);
+          setStats(null);
+          setHasNext(false);
         }
       }
-      if (selectedConnection !== "all" && item.dbConnection !== selectedConnection) {
-        return false;
-      }
-      if (selectedTable !== "all" && item.table !== selectedTable) {
-        return false;
-      }
-      if (selectedType !== "all" && item.type !== selectedType) {
-        return false;
-      }
-      if (selectedEncryption === "secure" && item.encryption !== "보안필요") {
-        return false;
-      }
-      if (selectedEncryption === "good" && item.encryption !== "양호") {
-        return false;
-      }
-      if (selectedRiskLevel === "high" && item.riskLevel !== "높음") {
-        return false;
-      }
-      if (selectedRiskLevel === "medium" && item.riskLevel !== "중간") {
-        return false;
-      }
-      if (selectedRiskLevel === "low" && item.riskLevel !== "낮음") {
-        return false;
-      }
-      return true;
-    });
-  }, [
-    privacyItems,
-    appliedSearchQuery,
-    selectedConnection,
-    selectedTable,
-    selectedType,
-    selectedEncryption,
-    selectedRiskLevel,
-  ]);
+    },
+    [
+      selectedConnection,
+      selectedTable,
+      selectedType,
+      selectedEncryption,
+      selectedRiskLevel,
+      appliedSearchQuery,
+      useMock,
+    ],
+  );
 
-  const totalItems = filteredItems.length;
-  const highRiskItems = filteredItems.filter((item) => item.riskLevel === "높음")
-    .length;
-  const encryptedItems = filteredItems.filter(
-    (item) => item.encryption === "양호",
-  ).length;
-  const encryptionRate =
-    totalItems === 0 ? 0 : Math.round((encryptedItems / totalItems) * 100);
-  const totalRecords = 626500;
+  useEffect(() => {
+    const id = setTimeout(() => {
+      loadConnections();
+    }, 0);
+    return () => clearTimeout(id);
+  }, [loadConnections]);
 
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setSelectedTable("all");
+      if (selectedConnection === "all") {
+        setTables([]);
+        return;
+      }
+      loadTables(Number(selectedConnection));
+    }, 0);
+    return () => clearTimeout(id);
+  }, [selectedConnection, loadTables]);
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setLoading(true);
+      loadColumns(0, false).finally(() => setLoading(false));
+    }, 0);
+    return () => clearTimeout(id);
+  }, [loadColumns]);
 
   const handleSearch = () => {
     setAppliedSearchQuery(searchQuery);
+    setPage(0);
   };
 
   const handleReset = () => {
@@ -169,29 +292,26 @@ export default function DbPrivacyListPage() {
     setSelectedType("all");
     setSelectedEncryption("all");
     setSelectedRiskLevel("all");
+    setPage(0);
   };
 
-  const columns: TableColumn<PrivacyItem>[] = [
-    {
-      id: "dbConnection",
-      label: "DB 연결",
-      width: "2fr",
-    },
-    {
-      id: "table",
-      label: "테이블",
-      width: "1.5fr",
-    },
-    {
-      id: "column",
-      label: "컬럼",
-      width: "1.5fr",
-    },
-    {
-      id: "type",
-      label: "유형",
-      width: "1.5fr",
-    },
+  const handleLoadMore = () => {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    setLoading(true);
+    loadColumns(nextPage, true).finally(() => setLoading(false));
+  };
+
+  const totalItems = stats?.totalItems ?? 0;
+  const highRiskItems = stats?.highRiskItems ?? 0;
+  const encryptionRate = stats?.encryptionRate ?? 0;
+  const totalRecords = stats?.totalRecords ?? 0;
+
+  const columns: TableColumn<TableRow>[] = [
+    { id: "dbConnection", label: "DB 연결", width: "2fr" },
+    { id: "table", label: "테이블", width: "1.5fr" },
+    { id: "column", label: "컬럼", width: "1.5fr" },
+    { id: "type", label: "유형", width: "1.5fr" },
     {
       id: "encryption",
       label: "암호화",
@@ -236,13 +356,16 @@ export default function DbPrivacyListPage() {
         );
       },
     },
-    {
-      id: "scanDateTime",
-      label: "스캔일시",
-      width: "1.5fr",
-      align: "left",
-    },
+    { id: "scanDateTime", label: "스캔일시", width: "1.5fr", align: "left" },
   ];
+
+  if (error && rows.length === 0) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center gap-4 p-6 text-white">
+        <p className="text-[var(--color-coral-text)]">{error}</p>
+      </div>
+    );
+  }
 
   return (
     <div className="h-full flex flex-col p-6 gap-5 overflow-hidden">
@@ -261,7 +384,7 @@ export default function DbPrivacyListPage() {
         />
         <StatCard
           title="암호화율"
-          value={`${encryptionRate}%`}
+          value={`${typeof encryptionRate === "number" ? encryptionRate.toFixed(1) : encryptionRate}%`}
           icon={<Lock className="size-5" />}
           colorScheme="purple"
         />
@@ -279,13 +402,14 @@ export default function DbPrivacyListPage() {
           onSearchQueryChange={setSearchQuery}
           onSearch={handleSearch}
           onReset={handleReset}
+          searchPlaceholder="컬럼명·테이블명 검색"
           connectionOptions={connectionOptions}
           selectedConnection={selectedConnection}
           onConnectionChange={setSelectedConnection}
           tableOptions={tableOptions}
           selectedTable={selectedTable}
           onTableChange={setSelectedTable}
-          typeOptions={typeOptions}
+          typeOptions={PII_TYPE_OPTIONS}
           selectedType={selectedType}
           onTypeChange={setSelectedType}
           selectedEncryption={selectedEncryption}
@@ -295,13 +419,45 @@ export default function DbPrivacyListPage() {
         />
 
         <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-          <Table
-            columns={columns}
-            data={filteredItems}
-            scrollable
-            maxBodyHeight="100%"
-            className="h-full"
-          />
+          {loading && rows.length === 0 ? (
+            <div className="flex-1 flex items-center justify-center text-white">
+              <div
+                className="size-10 rounded-full border-2 border-[var(--color-main-bg)] border-t-transparent animate-spin"
+                aria-label="로딩 중"
+              />
+            </div>
+          ) : rows.length === 0 ? (
+            <div className="flex-1 flex flex-col items-center justify-center gap-2 text-white/70 text-center px-4">
+              {selectedConnection !== "all"
+                ? "선택한 연결에 스캔 결과가 없습니다."
+                : "스캔된 PII 컬럼이 없습니다."}
+              <span className="text-sm">
+                DB 연결 관리에서 스캔을 실행한 뒤 다시 조회해 주세요.
+              </span>
+            </div>
+          ) : (
+            <>
+              <Table
+                columns={columns}
+                data={rows}
+                scrollable
+                maxBodyHeight="100%"
+                className="h-full"
+              />
+              {hasNext && (
+                <div className="shrink-0 pt-3 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={handleLoadMore}
+                    disabled={loading}
+                    className="px-4 py-2 rounded-md border border-[var(--color-content-border)] bg-[var(--color-sidebar-bg)] text-white text-sm hover:opacity-90 disabled:opacity-50"
+                  >
+                    {loading ? "로딩 중..." : "더보기"}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/views/db-privacy-list/ui/Page.tsx
+++ b/src/views/db-privacy-list/ui/Page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { useSearchParams } from "next/navigation";
 import { Table as TableIcon, AlertTriangle, Lock, Database } from "lucide-react";
 import {
   StatCard,
@@ -70,51 +69,7 @@ const PII_TYPE_OPTIONS = [
 
 const PAGE_SIZE = 20;
 
-/** 테스트용 샘플 행 (URL에 ?mock=1 일 때 API 빈 응답 시 표시) */
-const SAMPLE_ROWS: TableRow[] = [
-  {
-    id: "1",
-    dbConnection: "운영 DB (PostgreSQL)",
-    table: "users",
-    column: "email",
-    type: "이메일",
-    encryption: "보안필요",
-    riskLevel: "높음",
-    scanDateTime: "2026.01.29 02:00",
-  },
-  {
-    id: "2",
-    dbConnection: "운영 DB (PostgreSQL)",
-    table: "customers",
-    column: "phone",
-    type: "전화번호",
-    encryption: "양호",
-    riskLevel: "낮음",
-    scanDateTime: "2026.01.29 02:00",
-  },
-  {
-    id: "3",
-    dbConnection: "운영 DB (PostgreSQL)",
-    table: "orders",
-    column: "delivery_address",
-    type: "주소",
-    encryption: "보안필요",
-    riskLevel: "중간",
-    scanDateTime: "2026.01.28 14:30",
-  },
-];
-
-const SAMPLE_STATS = {
-  totalItems: 42,
-  highRiskItems: 15,
-  encryptionRate: 85.5,
-  totalRecords: 125_000,
-};
-
 export default function DbPrivacyListPage() {
-  const searchParams = useSearchParams();
-  const useMock = searchParams.get("mock") === "1";
-
   const [connections, setConnections] = useState<DbPiiConnection[]>([]);
   const [tables, setTables] = useState<DbPiiTable[]>([]);
   const [rows, setRows] = useState<TableRow[]>([]);
@@ -192,16 +147,9 @@ export default function DbPrivacyListPage() {
         size: PAGE_SIZE,
       });
       if (!res.success) {
-        if (useMock && !append) {
-          setError(null);
-          setRows(SAMPLE_ROWS);
-          setStats(SAMPLE_STATS);
-          setHasNext(false);
-        } else {
-          setError(res.message ?? "컬럼 목록을 불러오지 못했습니다.");
-          if (!append) setRows([]);
-          setHasNext(false);
-        }
+        setError(res.message ?? "컬럼 목록을 불러오지 못했습니다.");
+        if (!append) setRows([]);
+        setHasNext(false);
         return;
       }
       setError(null);
@@ -219,10 +167,6 @@ export default function DbPrivacyListPage() {
           setStats(res.result.stats ?? null);
           const slice = rawContent as { hasNext?: boolean } | undefined;
           setHasNext(Boolean(slice?.hasNext));
-        } else if (useMock && !append) {
-          setRows(SAMPLE_ROWS);
-          setStats(SAMPLE_STATS);
-          setHasNext(false);
         } else {
           if (!append) setRows([]);
           setStats(res.result.stats ?? null);
@@ -230,15 +174,9 @@ export default function DbPrivacyListPage() {
           setHasNext(Boolean(slice?.hasNext));
         }
       } else {
-        if (useMock && !append) {
-          setRows(SAMPLE_ROWS);
-          setStats(SAMPLE_STATS);
-          setHasNext(false);
-        } else {
-          if (!append) setRows([]);
-          setStats(null);
-          setHasNext(false);
-        }
+        if (!append) setRows([]);
+        setStats(null);
+        setHasNext(false);
       }
     },
     [
@@ -248,7 +186,6 @@ export default function DbPrivacyListPage() {
       selectedEncryption,
       selectedRiskLevel,
       appliedSearchQuery,
-      useMock,
     ],
   );
 


### PR DESCRIPTION
## 개요

- DB 개인정보 목록 화면 API 연동 (Mock 제거 → 실제 백엔드 데이터)

## 변경 사항
- **features/db-pii** API: 5-1 커넥션, 5-2 테이블, 5-3 컬럼·통계 (types, fetchWithAuth, 예외 처리)
- **views/db-privacy-list** Mock 제거, 5-1/5-2/5-3 연동, 필드 매핑(riskLevel·encrypted·lastScannedAt)
- 로딩·에러·빈 상태(스캔 안내), 5-3 페이지네이션(더보기)
- FilterSection searchPlaceholder "컬럼명·테이블명 검색"
- 커넥션 변경 시 테이블 선택 초기화
- effect 내 setState → setTimeout(0)으로 이탈
- lib/format.ts `formatScanDateTime` 추가
- 
## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 **To Reviewers**

<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **백엔드 데이터 통합** - 실제 데이터베이스 연결 및 테이블 정보를 로드하도록 변경
* **페이지네이션 지원** - "더보기" 버튼을 통한 추가 데이터 로드 기능 추가
* **동적 필터 옵션** - 연결, 테이블, PII 유형을 실제 데이터 기반으로 생성
* **실시간 통계** - 암호화율, 고위험 항목 수 등 API 응답 기반 통계 표시

## 개선 사항

* **검색 플레이스홀더 커스터마이징** - 필터 섹션에서 검색 텍스트 커스터마이징 가능
* **로딩 및 에러 처리** - 데이터 로드 중 로딩 표시기 및 에러 메시지 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->