### PR TITLE
[Feat] #49 DB 개인정보 이슈 api 연동

### DIFF
--- a/src/features/db-pii/api/db-pii-api.ts
+++ b/src/features/db-pii/api/db-pii-api.ts
@@ -5,6 +5,10 @@ import type {
   DbPiiTable,
   DbPiiColumnsResult,
   GetDbPiiColumnsParams,
+  DbPiiIssuesResult,
+  DbPiiIssueDetail,
+  DbPiiIssueStatusRequest,
+  DbPiiIssueStatusResult,
   ApiResponse,
 } from "./types";
 
@@ -108,5 +112,89 @@ export async function getDbPiiColumns(
     return data;
   } catch (e) {
     return toErrorResponse<DbPiiColumnsResult>(e);
+  }
+}
+
+/** 6-1. DB PII 이슈 목록·통계 조회 (백엔드 미구현 시 plain text "No static resource ..." 반환 가능) */
+export async function getDbPiiIssues(params?: {
+  page?: number;
+  size?: number;
+}): Promise<ApiResponse<DbPiiIssuesResult>> {
+  try {
+    const search = new URLSearchParams();
+    if (params?.page != null) search.set("page", String(params.page));
+    if (params?.size != null) search.set("size", String(params.size));
+    const qs = search.toString();
+    const url = qs ? `${BASE}/issues?${qs}` : `${BASE}/issues`;
+    const res = await fetchWithAuth(url);
+    const rawText = await res.text();
+    let data: ApiResponse<DbPiiIssuesResult> & { message?: string };
+    try {
+      data = (rawText ? JSON.parse(rawText) : {}) as ApiResponse<DbPiiIssuesResult>;
+    } catch {
+      data = { success: false, code: "", message: rawText, result: null, timestamp: "" };
+    }
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<DbPiiIssuesResult>(e);
+  }
+}
+
+/** 6-2. DB PII 이슈 상세 조회 */
+export async function getDbPiiIssueDetail(
+  issueId: number,
+): Promise<ApiResponse<DbPiiIssueDetail>> {
+  try {
+    const res = await fetchWithAuth(`${BASE}/issues/${issueId}`);
+    const data = (await res
+      .json()
+      .catch(() => ({}))) as ApiResponse<DbPiiIssueDetail>;
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<DbPiiIssueDetail>(e);
+  }
+}
+
+/** 6-3. DB PII 이슈 작업 상태 변경 */
+export async function patchDbPiiIssueStatus(
+  issueId: number,
+  body: DbPiiIssueStatusRequest,
+): Promise<ApiResponse<DbPiiIssueStatusResult>> {
+  try {
+    const res = await fetchWithAuth(`${BASE}/issues/${issueId}/status`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = (await res
+      .json()
+      .catch(() => ({}))) as ApiResponse<DbPiiIssueStatusResult>;
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<DbPiiIssueStatusResult>(e);
   }
 }

--- a/src/features/db-pii/api/db-pii-api.ts
+++ b/src/features/db-pii/api/db-pii-api.ts
@@ -14,6 +14,14 @@ import type {
 
 const BASE = `${API_BASE_URL}/api/db-pii`;
 
+const EMPTY_API_RESPONSE: ApiResponse<never> = {
+  success: false,
+  code: "",
+  message: "응답이 비어있습니다.",
+  result: null,
+  timestamp: "",
+};
+
 function errorMessage(
   data: { message?: string } | null,
   status: number,
@@ -23,12 +31,24 @@ function errorMessage(
 
 function toErrorResponse<T>(error: unknown): ApiResponse<T> {
   return {
-    success: false,
-    code: "",
+    ...EMPTY_API_RESPONSE,
     message: getApiErrorMessage(error),
-    result: null,
-    timestamp: "",
   };
+}
+
+function parseJsonResponse<T>(raw: string | null): ApiResponse<T> {
+  if (!raw?.trim()) return { ...EMPTY_API_RESPONSE } as ApiResponse<T>;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object"
+      ? ({ ...EMPTY_API_RESPONSE, ...parsed } as ApiResponse<T>)
+      : ({ ...EMPTY_API_RESPONSE } as ApiResponse<T>);
+  } catch {
+    return {
+      ...EMPTY_API_RESPONSE,
+      message: raw || EMPTY_API_RESPONSE.message,
+    } as ApiResponse<T>;
+  }
 }
 
 /** 5-1. DB PII 커넥션 목록 조회 (필터용) */
@@ -37,9 +57,8 @@ export async function getDbPiiConnections(): Promise<
 > {
   try {
     const res = await fetchWithAuth(`${BASE}/connections`);
-    const data = (await res
-      .json()
-      .catch(() => ({}))) as ApiResponse<DbPiiConnection[]>;
+    const raw = await res.text().catch(() => "");
+    const data = parseJsonResponse<DbPiiConnection[]>(raw || null);
     if (!res.ok) {
       return {
         ...data,
@@ -62,9 +81,8 @@ export async function getDbPiiTables(
     const res = await fetchWithAuth(
       `${BASE}/connections/${connectionId}/tables`,
     );
-    const data = (await res
-      .json()
-      .catch(() => ({}))) as ApiResponse<DbPiiTable[]>;
+    const raw = await res.text().catch(() => "");
+    const data = parseJsonResponse<DbPiiTable[]>(raw || null);
     if (!res.ok) {
       return {
         ...data,
@@ -98,9 +116,8 @@ export async function getDbPiiColumns(
     const qs = search.toString();
     const url = qs ? `${BASE}/columns?${qs}` : `${BASE}/columns`;
     const res = await fetchWithAuth(url);
-    const data = (await res
-      .json()
-      .catch(() => ({}))) as ApiResponse<DbPiiColumnsResult>;
+    const raw = await res.text().catch(() => "");
+    const data = parseJsonResponse<DbPiiColumnsResult>(raw || null);
     if (!res.ok) {
       return {
         ...data,
@@ -128,12 +145,7 @@ export async function getDbPiiIssues(params?: {
     const url = qs ? `${BASE}/issues?${qs}` : `${BASE}/issues`;
     const res = await fetchWithAuth(url);
     const rawText = await res.text();
-    let data: ApiResponse<DbPiiIssuesResult> & { message?: string };
-    try {
-      data = (rawText ? JSON.parse(rawText) : {}) as ApiResponse<DbPiiIssuesResult>;
-    } catch {
-      data = { success: false, code: "", message: rawText, result: null, timestamp: "" };
-    }
+    const data = parseJsonResponse<DbPiiIssuesResult>(rawText || null);
     if (!res.ok) {
       return {
         ...data,
@@ -154,9 +166,8 @@ export async function getDbPiiIssueDetail(
 ): Promise<ApiResponse<DbPiiIssueDetail>> {
   try {
     const res = await fetchWithAuth(`${BASE}/issues/${issueId}`);
-    const data = (await res
-      .json()
-      .catch(() => ({}))) as ApiResponse<DbPiiIssueDetail>;
+    const raw = await res.text().catch(() => "");
+    const data = parseJsonResponse<DbPiiIssueDetail>(raw || null);
     if (!res.ok) {
       return {
         ...data,
@@ -182,9 +193,8 @@ export async function patchDbPiiIssueStatus(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
-    const data = (await res
-      .json()
-      .catch(() => ({}))) as ApiResponse<DbPiiIssueStatusResult>;
+    const raw = await res.text().catch(() => "");
+    const data = parseJsonResponse<DbPiiIssueStatusResult>(raw || null);
     if (!res.ok) {
       return {
         ...data,

--- a/src/features/db-pii/api/types.ts
+++ b/src/features/db-pii/api/types.ts
@@ -69,3 +69,90 @@ export interface ApiResponse<T> {
   result: T | null;
   timestamp: string;
 }
+
+// --- 6. DB 개인정보 이슈 API ---
+
+/** 6-1. 이슈 목록 한 건 (테이블 그룹 내) */
+export interface DbPiiIssueItem {
+  issueId: number;
+  columnName: string;
+  piiTypeName: string;
+  piiTypeCode: string;
+  totalRecordsCount: number;
+  riskLevel: "HIGH" | "MEDIUM" | "LOW";
+  userStatus: "ISSUE" | "RUNNING" | "DONE";
+  detectedAt: string;
+}
+
+/** 6-1. 테이블별 이슈 그룹 */
+export interface DbPiiIssueTableGroup {
+  tableId: number;
+  tableName: string;
+  connectionName: string;
+  dbmsTypeName: string;
+  issueCount: number;
+  issues: DbPiiIssueItem[];
+}
+
+/** 6-1. 이슈 목록 stats */
+export interface DbPiiIssuesStats {
+  totalIssues: number;
+  highRiskCount: number;
+  mediumRiskCount: number;
+  lowRiskCount: number;
+  totalRecords: number;
+}
+
+/** 6-1. 이슈 목록 content (Slice) */
+export interface DbPiiIssuesContent {
+  content: DbPiiIssueTableGroup[];
+  pageable: { pageNumber: number; pageSize: number };
+  first: boolean;
+  last: boolean;
+  hasNext: boolean;
+  numberOfElements: number;
+}
+
+/** 6-1. 이슈 목록 result */
+export interface DbPiiIssuesResult {
+  stats: DbPiiIssuesStats;
+  content: DbPiiIssuesContent;
+}
+
+/** 6-2. 이슈 상세 (비암호화 데이터 포함) */
+export interface DbPiiUnencryptedRecord {
+  primaryKey: string;
+  value: string;
+}
+
+export interface DbPiiIssueDetail {
+  issueId: number;
+  connectionName: string;
+  dbmsTypeName: string;
+  tableName: string;
+  columnName: string;
+  piiTypeName: string;
+  piiTypeCode: string;
+  totalRecordsCount: number;
+  encRecordsCount: number;
+  unencryptedCount: number;
+  riskLevel: string;
+  userStatus: string;
+  issueStatus: string;
+  detectedAt: string;
+  managerName: string;
+  managerEmail: string;
+  unencryptedRecords: DbPiiUnencryptedRecord[];
+}
+
+/** 6-3. 작업 상태 변경 요청 */
+export interface DbPiiIssueStatusRequest {
+  userStatus: "ISSUE" | "RUNNING" | "DONE";
+}
+
+/** 6-3. 작업 상태 변경 응답 */
+export interface DbPiiIssueStatusResult {
+  issueId: number;
+  userStatus: string;
+  updatedAt: string;
+}

--- a/src/views/db-privacy-issues/lib/format.ts
+++ b/src/views/db-privacy-issues/lib/format.ts
@@ -1,0 +1,16 @@
+/** API detectedAt ISO 문자열 → 탐지 시각 표시 (YYYY.MM.DD HH:mm) */
+export function formatDetectedAt(isoString: string): string {
+  if (!isoString || typeof isoString !== "string") return "";
+  try {
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) return isoString;
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, "0");
+    const d = String(date.getDate()).padStart(2, "0");
+    const h = String(date.getHours()).padStart(2, "0");
+    const min = String(date.getMinutes()).padStart(2, "0");
+    return `${y}.${m}.${d} ${h}:${min}`;
+  } catch {
+    return isoString;
+  }
+}

--- a/src/views/db-privacy-issues/ui/IssueDetailModal.tsx
+++ b/src/views/db-privacy-issues/ui/IssueDetailModal.tsx
@@ -46,19 +46,26 @@ export default function IssueDetailModal({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     if (!open || issueId == null) {
       const id = setTimeout(() => {
+        if (cancelled) return;
         setDetail(null);
         setError(null);
       }, 0);
-      return () => clearTimeout(id);
+      return () => {
+        cancelled = true;
+        clearTimeout(id);
+      };
     }
     const id = setTimeout(() => {
+      if (cancelled) return;
       setLoading(true);
       setError(null);
     }, 0);
     getDbPiiIssueDetail(issueId)
       .then((res) => {
+        if (cancelled) return;
         if (res.success && res.result) {
           setDetail(res.result);
           setError(null);
@@ -68,11 +75,17 @@ export default function IssueDetailModal({
         }
       })
       .catch(() => {
+        if (cancelled) return;
         setDetail(null);
         setError("상세 정보를 불러오는 중 오류가 발생했습니다.");
       })
-      .finally(() => setLoading(false));
-    return () => clearTimeout(id);
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+      clearTimeout(id);
+    };
   }, [open, issueId]);
 
   const riskLevelLabel = detail

--- a/src/views/db-privacy-issues/ui/IssueDetailModal.tsx
+++ b/src/views/db-privacy-issues/ui/IssueDetailModal.tsx
@@ -1,60 +1,24 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 import { Lock } from "lucide-react";
 import { Modal } from "@/shared/ui";
 import { cn } from "@/shared/lib/utils";
+import { getDbPiiIssueDetail } from "@/features/db-pii";
+import type { DbPiiIssueDetail } from "@/features/db-pii";
+import { formatDetectedAt } from "../lib/format";
 
 type RiskLevel = "높음" | "중간" | "낮음";
 
-interface UnencryptedData extends Record<string, unknown> {
-  id: string;
-  user_id: number;
-  email: string;
-}
-
-interface IssueColumn {
-  id: string;
-  columnName: string;
-  personalInfoType: string;
-  recordCount: number;
-  riskLevel: RiskLevel;
-}
-
-interface TableIssue {
-  id: string;
-  tableName: string;
-  dbConnection: string;
-  manager: string;
-  issueCount: number;
-  columns: IssueColumn[];
-}
-
-interface IssueDetailModalProps {
-  open: boolean;
-  onClose: () => void;
-  issue: TableIssue;
-  column: IssueColumn | null;
-}
-
-const generateUnencryptedData = (issue: TableIssue): UnencryptedData[] => {
-  void issue;
-  return [
-    { id: "0", user_id: 0, email: "honggildong@naver.com" },
-    { id: "1", user_id: 1, email: "minsu.kim@gmail.com" },
-    { id: "2", user_id: 2, email: "jiyoon.lee@hanmail.net" },
-    { id: "3", user_id: 3, email: "yuna.park@gmail.com" },
-    { id: "4", user_id: 4, email: "seojun95@naver.com" },
-    { id: "5", user_id: 5, email: "hyejin.k@daum.net" },
-    { id: "6", user_id: 6, email: "chulsoo123@gmail.com" },
-    { id: "7", user_id: 7, email: "bora_lee@naver.com" },
-    { id: "8", user_id: 8, email: "junyoung.kim@gmail.com" },
-    { id: "9", user_id: 9, email: "somin88@hanmail.net" },
-  ];
+const riskLevelToLabel: Record<string, RiskLevel> = {
+  HIGH: "높음",
+  MEDIUM: "중간",
+  LOW: "낮음",
 };
 
-const getRiskLevelColor = (riskLevel: RiskLevel): string => {
-  switch (riskLevel) {
+const getRiskLevelColor = (riskLevel: string): string => {
+  const label = riskLevelToLabel[riskLevel] ?? riskLevel;
+  switch (label) {
     case "높음":
       return "text-[var(--color-coral-text)]";
     case "중간":
@@ -66,78 +30,93 @@ const getRiskLevelColor = (riskLevel: RiskLevel): string => {
   }
 };
 
+interface IssueDetailModalProps {
+  open: boolean;
+  onClose: () => void;
+  issueId: number | null;
+}
+
 export default function IssueDetailModal({
   open,
   onClose,
-  issue,
-  column,
+  issueId,
 }: IssueDetailModalProps) {
-  const unencryptedData = useMemo(
-    () => generateUnencryptedData(issue),
-    [issue],
-  );
+  const [detail, setDetail] = useState<DbPiiIssueDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const selectedColumn = column ?? issue.columns[0];
+  useEffect(() => {
+    if (!open || issueId == null) {
+      const id = setTimeout(() => {
+        setDetail(null);
+        setError(null);
+      }, 0);
+      return () => clearTimeout(id);
+    }
+    const id = setTimeout(() => {
+      setLoading(true);
+      setError(null);
+    }, 0);
+    getDbPiiIssueDetail(issueId)
+      .then((res) => {
+        if (res.success && res.result) {
+          setDetail(res.result);
+          setError(null);
+        } else {
+          setDetail(null);
+          setError(res.message ?? "상세 정보를 불러오지 못했습니다.");
+        }
+      })
+      .catch(() => {
+        setDetail(null);
+        setError("상세 정보를 불러오는 중 오류가 발생했습니다.");
+      })
+      .finally(() => setLoading(false));
+    return () => clearTimeout(id);
+  }, [open, issueId]);
 
-  // 담당자 이메일 매핑 (실제로는 API에서 가져올 데이터)
-  const managerEmailMap: Record<string, string> = {
-    "홍길동 대리": "honggildong@naver.com",
-    "김철수 대리": "chulsoo123@gmail.com",
-    "이순신 과장": "sunsin.lee@naver.com",
-    "박영희 대리": "younghee.park@example.com",
-    "최민수 과장": "minsu.choi@example.com",
-  };
+  const riskLevelLabel = detail
+    ? riskLevelToLabel[detail.riskLevel] ?? detail.riskLevel
+    : "";
 
-  const managerEmail = managerEmailMap[issue.manager] || "unknown@example.com";
+  const firstGridFields = detail
+    ? [
+        { label: "테이블 명", value: detail.tableName },
+        { label: "컬럼명", value: detail.columnName },
+        { label: "개인정보 유형", value: detail.piiTypeName },
+        {
+          label: "위험도",
+          value: riskLevelLabel,
+          className: cn(
+            "font-semibold text-sm",
+            getRiskLevelColor(detail.riskLevel),
+          ),
+        },
+      ]
+    : [];
 
-  // 첫 번째 그리드 필드 정의
-  const firstGridFields = [
-    {
-      label: "테이블 명",
-      value: issue.tableName,
-    },
-    {
-      label: "컬럼명",
-      value: selectedColumn.columnName,
-    },
-    {
-      label: "개인정보 유형",
-      value: selectedColumn.personalInfoType,
-    },
-    {
-      label: "위험도",
-      value: selectedColumn.riskLevel,
-      className: cn(
-        "font-semibold text-sm",
-        getRiskLevelColor(selectedColumn.riskLevel),
-      ),
-    },
-  ];
+  const secondGridFields = detail
+    ? [
+        {
+          label: "보안필요 레코드 수 / 총 레코드 수",
+          value: `${detail.unencryptedCount.toLocaleString()}건 / ${detail.totalRecordsCount.toLocaleString()}건`,
+          className: "tabular-nums",
+        },
+        {
+          label: "스캔 일시",
+          value: formatDetectedAt(detail.detectedAt),
+        },
+      ]
+    : [];
 
-  // 두 번째 그리드 필드 정의
-  const secondGridFields = [
-    {
-      label: "보안필요 레코드 수 / 총 레코드 수",
-      value: `100건 / ${selectedColumn.recordCount.toLocaleString()}건`,
-      className: "tabular-nums",
-    },
-    {
-      label: "스캔 일시",
-      value: "2025.01.13 19:30",
-    },
-  ];
+  const thirdGridFields = detail
+    ? [
+        { label: "담당자", value: detail.managerName },
+        { label: "담당자 이메일", value: detail.managerEmail },
+      ]
+    : [];
 
-  // 세 번째 그리드 필드 정의
-  const thirdGridFields = [
-    {
-      label: "담당자",
-      value: issue.manager,
-    },
-    {
-      label: "담당자 이메일",
-      value: managerEmail,
-    },
-  ];
+  const records = detail?.unencryptedRecords ?? [];
 
   return (
     <Modal
@@ -148,112 +127,138 @@ export default function IssueDetailModal({
       className="max-w-5xl !max-h-[80vh]"
     >
       <div className="flex flex-col gap-5 px-4 py-2">
-        <div className="flex items-start gap-3 p-4 rounded-lg bg-[var(--color-coral-bg)]/15 border border-[var(--color-coral-border)]">
-          <Lock className="size-5 shrink-0 text-[var(--color-coral-text)] mt-0.5" />
-          <div className="flex-1">
-            <p className="text-sm font-medium text-[var(--color-coral-text)] mb-1">
-              암호화되지 않은 개인정보
-            </p>
-            <p className="text-sm text-[var(--color-text-light-gray)]">
-              이 컬럼의 개인정보는 평문으로 저장되어 있어 보안 위험이 있습니다.
-              즉시 암호화 조치가 필요합니다.
-            </p>
+        {loading ? (
+          <div className="flex items-center justify-center py-12 text-white">
+            <div
+              className="size-10 rounded-full border-2 border-[var(--color-main-bg)] border-t-transparent animate-spin"
+              aria-label="로딩 중"
+            />
           </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-8">
-          <div className="flex flex-col gap-3">
-            <h3 className="text-sm font-semibold text-white text-center">
-              암호화되지 않은 데이터 목록
-            </h3>
-            <div className="rounded-lg border border-[var(--color-content-border)] overflow-hidden">
-              <table className="w-full text-sm">
-                <thead className="bg-[var(--color-sidebar-bg)]">
-                  <tr className="text-[var(--color-text-light-gray)]">
-                    <th className="px-4 py-3 text-left border-b border-r border-[var(--color-content-border)] w-[110px]">
-                      user_id
-                    </th>
-                    <th className="px-4 py-3 text-left border-b border-[var(--color-content-border)]">
-                      email
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {unencryptedData.map((row) => (
-                    <tr
-                      key={row.id}
-                      className="border-b border-[var(--color-content-border)] last:border-b-0"
-                    >
-                      <td className="px-4 py-3 text-white border-r border-[var(--color-content-border)] tabular-nums">
-                        {row.user_id}
-                      </td>
-                      <td className="px-4 py-3 text-white">{row.email}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+        ) : error ? (
+          <p className="py-6 text-center text-[var(--color-coral-text)]">
+            {error}
+          </p>
+        ) : detail ? (
+          <>
+            <div className="flex items-start gap-3 p-4 rounded-lg bg-[var(--color-coral-bg)]/15 border border-[var(--color-coral-border)]">
+              <Lock className="size-5 shrink-0 text-[var(--color-coral-text)] mt-0.5" />
+              <div className="flex-1">
+                <p className="text-sm font-medium text-[var(--color-coral-text)] mb-1">
+                  암호화되지 않은 개인정보
+                </p>
+                <p className="text-sm text-[var(--color-text-light-gray)]">
+                  이 컬럼의 개인정보는 평문으로 저장되어 있어 보안 위험이 있습니다.
+                  즉시 암호화 조치가 필요합니다.
+                </p>
+              </div>
             </div>
-          </div>
 
-          <div className="flex flex-col pt-[30px] pb-6">
-            <div className="space-y-7">
-              <div>
-                <p className="text-[var(--color-text-light-gray)] mb-1.5 text-xs font-medium">
-                  DB 연결
-                </p>
-                <p className="text-white font-semibold text-sm">
-                  {issue.dbConnection}
-                </p>
-              </div>
-              <div className="grid grid-cols-2 gap-x-6 gap-y-7">
-                {firstGridFields.map((field, index) => (
-                  <div key={index}>
-                    <p className="text-[var(--color-text-light-gray)] mb-1.5 text-xs font-medium">
-                      {field.label}
-                    </p>
-                    <p
-                      className={cn(
-                        "text-white font-semibold text-sm",
-                        field.className,
+            <div className="grid grid-cols-2 gap-8">
+              <div className="flex flex-col gap-3">
+                <h3 className="text-sm font-semibold text-white text-center">
+                  암호화되지 않은 데이터 목록
+                </h3>
+                <div className="rounded-lg border border-[var(--color-content-border)] overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead className="bg-[var(--color-sidebar-bg)]">
+                      <tr className="text-[var(--color-text-light-gray)]">
+                        <th className="px-4 py-3 text-left border-b border-r border-[var(--color-content-border)] w-[110px]">
+                          primaryKey
+                        </th>
+                        <th className="px-4 py-3 text-left border-b border-[var(--color-content-border)]">
+                          value
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {records.length === 0 ? (
+                        <tr>
+                          <td
+                            colSpan={2}
+                            className="px-4 py-6 text-center text-[var(--color-text-light-gray)]"
+                          >
+                            비암호화 데이터가 없습니다.
+                          </td>
+                        </tr>
+                      ) : (
+                        records.map((row, idx) => (
+                          <tr
+                            key={idx}
+                            className="border-b border-[var(--color-content-border)] last:border-b-0"
+                          >
+                            <td className="px-4 py-3 text-white border-r border-[var(--color-content-border)] tabular-nums">
+                              {row.primaryKey}
+                            </td>
+                            <td className="px-4 py-3 text-white">{row.value}</td>
+                          </tr>
+                        ))
                       )}
-                    >
-                      {field.value}
-                    </p>
-                  </div>
-                ))}
+                    </tbody>
+                  </table>
+                </div>
               </div>
-              <div className="grid grid-cols-2 gap-x-6 gap-y-7">
-                {secondGridFields.map((field, index) => (
-                  <div key={index}>
+
+              <div className="flex flex-col pt-[30px] pb-6">
+                <div className="space-y-7">
+                  <div>
                     <p className="text-[var(--color-text-light-gray)] mb-1.5 text-xs font-medium">
-                      {field.label}
-                    </p>
-                    <p
-                      className={cn(
-                        "text-white font-semibold text-sm",
-                        field.className,
-                      )}
-                    >
-                      {field.value}
-                    </p>
-                  </div>
-                ))}
-              </div>
-              <div className="grid grid-cols-2 gap-x-6 gap-y-7">
-                {thirdGridFields.map((field, index) => (
-                  <div key={index}>
-                    <p className="text-[var(--color-text-light-gray)] mb-1.5 text-xs font-medium">
-                      {field.label}
+                      DB 연결
                     </p>
                     <p className="text-white font-semibold text-sm">
-                      {field.value}
+                      {detail.connectionName} ({detail.dbmsTypeName})
                     </p>
                   </div>
-                ))}
+                  <div className="grid grid-cols-2 gap-x-6 gap-y-7">
+                    {firstGridFields.map((field, index) => (
+                      <div key={index}>
+                        <p className="text-[var(--color-text-light-gray)] mb-1.5 text-xs font-medium">
+                          {field.label}
+                        </p>
+                        <p
+                          className={cn(
+                            "text-white font-semibold text-sm",
+                            field.className,
+                          )}
+                        >
+                          {field.value}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="grid grid-cols-2 gap-x-6 gap-y-7">
+                    {secondGridFields.map((field, index) => (
+                      <div key={index}>
+                        <p className="text-[var(--color-text-light-gray)] mb-1.5 text-xs font-medium">
+                          {field.label}
+                        </p>
+                        <p
+                          className={cn(
+                            "text-white font-semibold text-sm",
+                            field.className,
+                          )}
+                        >
+                          {field.value}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="grid grid-cols-2 gap-x-6 gap-y-7">
+                    {thirdGridFields.map((field, index) => (
+                      <div key={index}>
+                        <p className="text-[var(--color-text-light-gray)] mb-1.5 text-xs font-medium">
+                          {field.label}
+                        </p>
+                        <p className="text-white font-semibold text-sm">
+                          {field.value}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
+          </>
+        ) : null}
       </div>
     </Modal>
   );

--- a/src/views/db-privacy-issues/ui/Page.tsx
+++ b/src/views/db-privacy-issues/ui/Page.tsx
@@ -91,59 +91,63 @@ export default function DbPrivacyIssuesPage() {
   const [selectedIssueId, setSelectedIssueId] = useState<number | null>(null);
   const [statusChangingId, setStatusChangingId] = useState<number | null>(null);
 
-  const loadIssues = useCallback(async (pageNum: number, append: boolean) => {
-    const res = await getDbPiiIssues({ page: pageNum, size: PAGE_SIZE });
-    if (!res.success) {
-      const msg = res.message ?? "";
-      if (NOT_IMPLEMENTED_PATTERN.test(msg)) {
-        setApiNotReady(true);
-        setError(null);
+  const loadIssues = useCallback(
+    async (pageNum: number, append: boolean): Promise<boolean> => {
+      const res = await getDbPiiIssues({ page: pageNum, size: PAGE_SIZE });
+      if (!res.success) {
+        const msg = res.message ?? "";
+        if (NOT_IMPLEMENTED_PATTERN.test(msg)) {
+          setApiNotReady(true);
+          setError(null);
+          if (!append) setTableIssues([]);
+          setStats(null);
+          setHasNext(false);
+          return false;
+        }
+        setApiNotReady(false);
+        setError(msg || "이슈 목록을 불러오지 못했습니다.");
         if (!append) setTableIssues([]);
-        setStats(null);
         setHasNext(false);
-        return;
+        return false;
       }
       setApiNotReady(false);
-      setError(msg || "이슈 목록을 불러오지 못했습니다.");
-      if (!append) setTableIssues([]);
-      setHasNext(false);
-      return;
-    }
-    setApiNotReady(false);
-    setError(null);
-    if (res.result) {
-      const rawContent = res.result.content;
-      // 명세: result.content = { content: [], hasNext, ... }. 일부 백엔드는 result.content = [] 로 보낼 수 있음
-      const contentArray: DbPiiIssueTableGroup[] = Array.isArray(rawContent)
-        ? rawContent
-        : Array.isArray((rawContent as { content?: DbPiiIssueTableGroup[] })?.content)
-          ? (rawContent as { content: DbPiiIssueTableGroup[] }).content
-          : [];
-      const list = contentArray
-        .filter(
-          (g): g is DbPiiIssueTableGroup =>
-            g != null &&
-            typeof g.tableId === "number" &&
-            Array.isArray(g.issues),
-        )
-        .map(apiGroupToTableIssue);
-      if (append) {
-        setTableIssues((prev) => [...prev, ...list]);
-      } else {
-        setTableIssues(list);
+      setError(null);
+      if (res.result) {
+        const rawContent = res.result.content;
+        // 명세: result.content = { content: [], hasNext, ... }. 일부 백엔드는 result.content = [] 로 보낼 수 있음
+        const contentArray: DbPiiIssueTableGroup[] = Array.isArray(rawContent)
+          ? rawContent
+          : Array.isArray((rawContent as { content?: DbPiiIssueTableGroup[] })?.content)
+            ? (rawContent as { content: DbPiiIssueTableGroup[] }).content
+            : [];
+        const list = contentArray
+          .filter(
+            (g): g is DbPiiIssueTableGroup =>
+              g != null &&
+              typeof g.tableId === "number" &&
+              Array.isArray(g.issues),
+          )
+          .map(apiGroupToTableIssue);
+        if (append) {
+          setTableIssues((prev) => [...prev, ...list]);
+        } else {
+          setTableIssues(list);
+        }
+        setStats(res.result.stats ?? null);
+        const slice =
+          rawContent && !Array.isArray(rawContent)
+            ? (rawContent as { hasNext?: boolean })
+            : null;
+        setHasNext(Boolean(slice?.hasNext));
+        return true;
       }
-      setStats(res.result.stats ?? null);
-      const slice =
-        rawContent && !Array.isArray(rawContent)
-          ? (rawContent as { hasNext?: boolean })
-          : null;
-      setHasNext(Boolean(slice?.hasNext));
-    } else {
       if (!append) setTableIssues([]);
       setStats(null);
       setHasNext(false);
-    }
-  }, []);
+      return false;
+    },
+    [],
+  );
 
   useEffect(() => {
     const id = setTimeout(() => {
@@ -199,9 +203,12 @@ export default function DbPrivacyIssuesPage() {
 
   const handleLoadMore = () => {
     const nextPage = page + 1;
-    setPage(nextPage);
     setLoading(true);
-    loadIssues(nextPage, true).finally(() => setLoading(false));
+    loadIssues(nextPage, true)
+      .then((ok) => {
+        if (ok) setPage(nextPage);
+      })
+      .finally(() => setLoading(false));
   };
 
   const getWorkStatusButtonProps = (status: WorkStatus) => {

--- a/src/views/db-privacy-issues/ui/Page.tsx
+++ b/src/views/db-privacy-issues/ui/Page.tsx
@@ -1,17 +1,45 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { AlertTriangle, Lock, FileText, Database } from "lucide-react";
 import { StatCard, Table, Button, TableSection } from "@/shared/ui";
 import type { TableColumn } from "@/shared/ui";
 import { cn } from "@/shared/lib/utils";
 import IssueDetailModal from "./IssueDetailModal";
+import {
+  getDbPiiIssues,
+  patchDbPiiIssueStatus,
+} from "@/features/db-pii";
+import type {
+  DbPiiIssueTableGroup,
+  DbPiiIssueItem,
+  DbPiiIssuesStats,
+} from "@/features/db-pii";
 
 type RiskLevel = "높음" | "중간" | "낮음";
 type WorkStatus = "진행중" | "해결완료" | "진행시작";
 
+const riskLevelToLabel: Record<string, RiskLevel> = {
+  HIGH: "높음",
+  MEDIUM: "중간",
+  LOW: "낮음",
+};
+
+const userStatusToLabel: Record<string, WorkStatus> = {
+  ISSUE: "진행시작",
+  RUNNING: "진행중",
+  DONE: "해결완료",
+};
+
+const workStatusToApi: Record<WorkStatus, "ISSUE" | "RUNNING" | "DONE"> = {
+  진행시작: "ISSUE",
+  진행중: "RUNNING",
+  해결완료: "DONE",
+};
+
 interface IssueColumn extends Record<string, unknown> {
   id: string;
+  issueId: number;
   columnName: string;
   personalInfoType: string;
   recordCount: number;
@@ -21,205 +49,159 @@ interface IssueColumn extends Record<string, unknown> {
 
 interface TableIssue {
   id: string;
+  tableId: number;
   tableName: string;
   dbConnection: string;
-  manager: string;
   issueCount: number;
   columns: IssueColumn[];
 }
 
-const generateMockIssues = (): TableIssue[] => {
-  return [
-    {
-      id: "users",
-      tableName: "users",
-      dbConnection: "운영 DB (PostgreSQL)",
-      manager: "홍길동 대리",
-      issueCount: 1,
-      columns: [
-        {
-          id: "users-email",
-          columnName: "email",
-          personalInfoType: "이메일",
-          recordCount: 125_000,
-          riskLevel: "낮음",
-          workStatus: "진행중",
-        },
-      ],
-    },
-    {
-      id: "orders",
-      tableName: "orders",
-      dbConnection: "운영 DB (PostgreSQL)",
-      manager: "김철수 대리",
-      issueCount: 2,
-      columns: [
-        {
-          id: "orders-delivery_address",
-          columnName: "delivery_address",
-          personalInfoType: "주소",
-          recordCount: 89_000,
-          riskLevel: "높음",
-          workStatus: "진행중",
-        },
-        {
-          id: "orders-phone_number",
-          columnName: "phone_number",
-          personalInfoType: "전화번호",
-          recordCount: 125_000,
-          riskLevel: "중간",
-          workStatus: "해결완료",
-        },
-      ],
-    },
-    {
-      id: "customer_backup",
-      tableName: "customer_backup",
-      dbConnection: "운영 DB (PostgreSQL)",
-      manager: "이순신 과장",
-      issueCount: 1,
-      columns: [
-        {
-          id: "customer_backup-email",
-          columnName: "email",
-          personalInfoType: "이메일",
-          recordCount: 7_000,
-          riskLevel: "낮음",
-          workStatus: "진행시작",
-        },
-      ],
-    },
-    {
-      id: "payments",
-      tableName: "payments",
-      dbConnection: "레거시 시스템 (Oracle)",
-      manager: "박영희 대리",
-      issueCount: 3,
-      columns: [
-        {
-          id: "payments-card_number",
-          columnName: "card_number",
-          personalInfoType: "계좌번호",
-          recordCount: 45_000,
-          riskLevel: "높음",
-          workStatus: "진행시작",
-        },
-        {
-          id: "payments-ssn",
-          columnName: "ssn",
-          personalInfoType: "주민등록번호",
-          recordCount: 32_000,
-          riskLevel: "높음",
-          workStatus: "진행중",
-        },
-        {
-          id: "payments-name",
-          columnName: "name",
-          personalInfoType: "이름",
-          recordCount: 78_000,
-          riskLevel: "중간",
-          workStatus: "해결완료",
-        },
-      ],
-    },
-    {
-      id: "employees",
-      tableName: "employees",
-      dbConnection: "고객 DB (MySQL)",
-      manager: "최민수 과장",
-      issueCount: 2,
-      columns: [
-        {
-          id: "employees-phone",
-          columnName: "phone",
-          personalInfoType: "전화번호",
-          recordCount: 156_000,
-          riskLevel: "중간",
-          workStatus: "진행중",
-        },
-        {
-          id: "employees-address",
-          columnName: "address",
-          personalInfoType: "주소",
-          recordCount: 98_000,
-          riskLevel: "낮음",
-          workStatus: "진행시작",
-        },
-      ],
-    },
-  ];
-};
+function apiGroupToTableIssue(g: DbPiiIssueTableGroup): TableIssue {
+  return {
+    id: String(g.tableId),
+    tableId: g.tableId,
+    tableName: g.tableName,
+    dbConnection: `${g.connectionName} (${g.dbmsTypeName})`,
+    issueCount: g.issueCount,
+    columns: g.issues.map((item: DbPiiIssueItem) => ({
+      id: String(item.issueId),
+      issueId: item.issueId,
+      columnName: item.columnName,
+      personalInfoType: item.piiTypeName,
+      recordCount: item.totalRecordsCount,
+      riskLevel: riskLevelToLabel[item.riskLevel] ?? "낮음",
+      workStatus: userStatusToLabel[item.userStatus] ?? "진행시작",
+    })),
+  };
+}
+
+const PAGE_SIZE = 10;
+
+/** 백엔드에 6-1 API 미구현 시 반환하는 메시지. 이 경우 빈 목록으로 처리 */
+const NOT_IMPLEMENTED_PATTERN = /no static resource|api\/db-pii\/issues/i;
 
 export default function DbPrivacyIssuesPage() {
-  const [issues, setIssues] = useState<TableIssue[]>(generateMockIssues());
-  const [selected, setSelected] = useState<{
-    issueId: string;
-    columnId: string;
-  } | null>(null);
+  const [tableIssues, setTableIssues] = useState<TableIssue[]>([]);
+  const [stats, setStats] = useState<DbPiiIssuesStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [apiNotReady, setApiNotReady] = useState(false);
+  const [page, setPage] = useState(0);
+  const [hasNext, setHasNext] = useState(false);
+  const [selectedIssueId, setSelectedIssueId] = useState<number | null>(null);
+  const [statusChangingId, setStatusChangingId] = useState<number | null>(null);
 
-  const stats = useMemo(() => {
-    let totalColumns = 0;
-    let highRisk = 0;
-    let mediumRisk = 0;
-    let lowRisk = 0;
+  const loadIssues = useCallback(async (pageNum: number, append: boolean) => {
+    const res = await getDbPiiIssues({ page: pageNum, size: PAGE_SIZE });
+    if (!res.success) {
+      const msg = res.message ?? "";
+      if (NOT_IMPLEMENTED_PATTERN.test(msg)) {
+        setApiNotReady(true);
+        setError(null);
+        if (!append) setTableIssues([]);
+        setStats(null);
+        setHasNext(false);
+        return;
+      }
+      setApiNotReady(false);
+      setError(msg || "이슈 목록을 불러오지 못했습니다.");
+      if (!append) setTableIssues([]);
+      setHasNext(false);
+      return;
+    }
+    setApiNotReady(false);
+    setError(null);
+    if (res.result) {
+      const rawContent = res.result.content;
+      // 명세: result.content = { content: [], hasNext, ... }. 일부 백엔드는 result.content = [] 로 보낼 수 있음
+      const contentArray: DbPiiIssueTableGroup[] = Array.isArray(rawContent)
+        ? rawContent
+        : Array.isArray((rawContent as { content?: DbPiiIssueTableGroup[] })?.content)
+          ? (rawContent as { content: DbPiiIssueTableGroup[] }).content
+          : [];
+      const list = contentArray
+        .filter(
+          (g): g is DbPiiIssueTableGroup =>
+            g != null &&
+            typeof g.tableId === "number" &&
+            Array.isArray(g.issues),
+        )
+        .map(apiGroupToTableIssue);
+      if (append) {
+        setTableIssues((prev) => [...prev, ...list]);
+      } else {
+        setTableIssues(list);
+      }
+      setStats(res.result.stats ?? null);
+      const slice =
+        rawContent && !Array.isArray(rawContent)
+          ? (rawContent as { hasNext?: boolean })
+          : null;
+      setHasNext(Boolean(slice?.hasNext));
+    } else {
+      if (!append) setTableIssues([]);
+      setStats(null);
+      setHasNext(false);
+    }
+  }, []);
 
-    issues.forEach((issue) => {
-      totalColumns += issue.columns.length;
-      issue.columns.forEach((col) => {
-        if (col.riskLevel === "높음") highRisk++;
-        else if (col.riskLevel === "중간") mediumRisk++;
-        else if (col.riskLevel === "낮음") lowRisk++;
-      });
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setLoading(true);
+      loadIssues(0, false).finally(() => setLoading(false));
+    }, 0);
+    return () => clearTimeout(id);
+  }, [loadIssues]);
+
+  const handleCloseModal = () => setSelectedIssueId(null);
+
+  const handleRowDetailClick = (issueId: number) => {
+    setSelectedIssueId(issueId);
+  };
+
+  const getNextUserStatus = (
+    current: WorkStatus,
+  ): "RUNNING" | "DONE" => {
+    if (current === "진행시작") return "RUNNING";
+    return "DONE";
+  };
+
+  const handleWorkStatusClick = async (issueId: number) => {
+    const col = tableIssues
+      .flatMap((t) => t.columns)
+      .find((c) => c.issueId === issueId);
+    if (!col || col.workStatus === "해결완료") return;
+    const nextStatus = getNextUserStatus(col.workStatus);
+    setStatusChangingId(issueId);
+    const res = await patchDbPiiIssueStatus(issueId, {
+      userStatus: nextStatus,
     });
-
-    return {
-      totalColumns,
-      highRisk,
-      mediumRisk,
-      lowRisk,
-      totalPersonalInfo: 3630,
-    };
-  }, [issues]);
-
-  const handleCloseModal = () => {
-    setSelected(null);
+    setStatusChangingId(null);
+    if (res.success) {
+      setTableIssues((prev) =>
+        prev.map((t) => ({
+          ...t,
+          columns: t.columns.map((c) =>
+            c.issueId === issueId
+              ? {
+                  ...c,
+                  workStatus:
+                    nextStatus === "RUNNING" ? "진행중" : "해결완료",
+                }
+              : c,
+          ),
+        })),
+      );
+    } else {
+      alert(res.message ?? "상태 변경에 실패했습니다.");
+    }
   };
 
-  const selectedIssue = useMemo(() => {
-    if (!selected) return null;
-    return issues.find((i) => i.id === selected.issueId) ?? null;
-  }, [issues, selected]);
-
-  const selectedColumn = useMemo(() => {
-    if (!selected || !selectedIssue) return null;
-    return (
-      selectedIssue.columns.find((c) => c.id === selected.columnId) ?? null
-    );
-  }, [selected, selectedIssue]);
-
-  const handleRowDetailClick = (issueId: string, columnId: string) => {
-    setSelected({ issueId, columnId });
-  };
-
-  const handleWorkStatusClick = (issueId: string, columnId: string) => {
-    setIssues((prev) =>
-      prev.map((issue) => {
-        if (issue.id !== issueId) return issue;
-        return {
-          ...issue,
-          columns: issue.columns.map((col) => {
-            if (col.id !== columnId) return col;
-            const next: WorkStatus =
-              col.workStatus === "진행시작"
-                ? "진행중"
-                : col.workStatus === "진행중"
-                  ? "해결완료"
-                  : "해결완료";
-            return { ...col, workStatus: next };
-          }),
-        };
-      }),
-    );
+  const handleLoadMore = () => {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    setLoading(true);
+    loadIssues(nextPage, true).finally(() => setLoading(false));
   };
 
   const getWorkStatusButtonProps = (status: WorkStatus) => {
@@ -237,6 +219,12 @@ export default function DbPrivacyIssuesPage() {
         return { colorScheme: "main" as const, appearance: "solid" as const };
     }
   };
+
+  const totalIssues = stats?.totalIssues ?? 0;
+  const highRisk = stats?.highRiskCount ?? 0;
+  const mediumRisk = stats?.mediumRiskCount ?? 0;
+  const lowRisk = stats?.lowRiskCount ?? 0;
+  const totalRecords = stats?.totalRecords ?? 0;
 
   const getIssueColumns = (issue: TableIssue): TableColumn<IssueColumn>[] => [
     {
@@ -304,15 +292,17 @@ export default function DbPrivacyIssuesPage() {
           status === "진행시작"
             ? "bg-[var(--color-green-text)] text-black hover:opacity-90"
             : "";
+        const isLoading = statusChangingId === row.issueId;
         return (
           <Button
             size="sm"
             colorScheme={btn.colorScheme}
             appearance={btn.appearance}
             className={cn("min-w-[84px]", extraClass)}
-            onClick={() => handleWorkStatusClick(issue.id, row.id)}
+            disabled={isLoading || status === "해결완료"}
+            onClick={() => handleWorkStatusClick(row.issueId)}
           >
-            {status}
+            {isLoading ? "처리 중..." : status}
           </Button>
         );
       },
@@ -326,7 +316,7 @@ export default function DbPrivacyIssuesPage() {
         <button
           type="button"
           className="cursor-pointer text-sm font-semibold text-white/90 hover:text-white hover:underline underline-offset-4"
-          onClick={() => handleRowDetailClick(issue.id, row.id)}
+          onClick={() => handleRowDetailClick(row.issueId)}
         >
           상세보기
         </button>
@@ -334,76 +324,107 @@ export default function DbPrivacyIssuesPage() {
     },
   ];
 
+  if (error && tableIssues.length === 0) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center gap-4 p-6 text-white">
+        <p className="text-[var(--color-coral-text)]">{error}</p>
+      </div>
+    );
+  }
+
   return (
     <div className="h-full min-h-0 overflow-hidden flex flex-col p-6 gap-5">
       <div className="grid grid-cols-5 gap-4 shrink-0">
         <StatCard
           title="총 이슈 컬럼"
-          value={stats.totalColumns}
+          value={String(totalIssues)}
           icon={<AlertTriangle className="size-5" />}
           colorScheme="purple"
         />
         <StatCard
           title="위험도 높음"
-          value={stats.highRisk}
+          value={String(highRisk)}
           icon={<Lock className="size-5" />}
           colorScheme="coral"
         />
         <StatCard
           title="위험도 중간"
-          value={stats.mediumRisk}
+          value={String(mediumRisk)}
           icon={<Lock className="size-5" />}
           colorScheme="warning"
         />
         <StatCard
           title="위험도 낮음"
-          value={stats.lowRisk}
+          value={String(lowRisk)}
           icon={<Lock className="size-5" />}
           colorScheme="green"
         />
         <StatCard
           title="총 개인정보 수"
-          value={stats.totalPersonalInfo.toLocaleString()}
+          value={totalRecords.toLocaleString()}
           icon={<FileText className="size-5" />}
           colorScheme="mint"
         />
       </div>
 
-      {/* Only contents scroll; title stays fixed */}
       <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
         <h2 className="shrink-0 text-base font-semibold text-white px-1 pb-2">
           테이블별 암호화 이슈
         </h2>
-        <div className="flex-1 min-h-0 overflow-y-auto pr-0">
-          <div className="flex flex-col gap-3 pb-2">
-            {issues.map((issue) => (
-              <TableSection
-                key={issue.id}
-                icon={<Database className="size-5" />}
-                title={issue.tableName}
-                meta={`${issue.dbConnection}`}
-                badge={`${issue.issueCount}개 이슈`}
-                badgeVariant="plain"
-              >
-                <Table
-                  columns={getIssueColumns(issue)}
-                  data={issue.columns}
-                  className="border-0 rounded-t-none"
-                />
-              </TableSection>
-            ))}
+        {loading && tableIssues.length === 0 ? (
+          <div className="flex-1 flex items-center justify-center text-white">
+            <div
+              className="size-10 rounded-full border-2 border-[var(--color-main-bg)] border-t-transparent animate-spin"
+              aria-label="로딩 중"
+            />
           </div>
-        </div>
+        ) : tableIssues.length === 0 ? (
+          <div className="flex-1 flex items-center justify-center text-white/70">
+            {apiNotReady
+              ? "이슈 API가 준비되면 데이터가 표시됩니다. (백엔드 6-1 API 구현 필요)"
+              : "이슈가 없습니다."}
+          </div>
+        ) : (
+          <div className="flex-1 min-h-0 overflow-y-auto pr-0">
+            <div className="flex flex-col gap-3 pb-2">
+              {tableIssues.map((issue) => (
+                <TableSection
+                  key={issue.id}
+                  icon={<Database className="size-5" />}
+                  title={issue.tableName}
+                  meta={issue.dbConnection}
+                  badge={`${issue.issueCount}개 이슈`}
+                  badgeVariant="plain"
+                >
+                  <Table
+                    columns={getIssueColumns(issue)}
+                    data={issue.columns}
+                    className="border-0 rounded-t-none"
+                  />
+                </TableSection>
+              ))}
+            </div>
+            {hasNext && (
+              <div className="shrink-0 pt-3 flex justify-center pb-2">
+                <button
+                  type="button"
+                  onClick={handleLoadMore}
+                  disabled={loading}
+                  className="px-4 py-2 rounded-md border border-[var(--color-content-border)] bg-[var(--color-sidebar-bg)] text-white text-sm hover:opacity-90 disabled:opacity-50"
+                >
+                  {loading ? "로딩 중..." : "더보기"}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
-      {selectedIssue && (
-        <IssueDetailModal
-          open={selected != null}
-          onClose={handleCloseModal}
-          issue={selectedIssue}
-          column={selectedColumn}
-        />
-      )}
+      <IssueDetailModal
+        open={selectedIssueId != null}
+        onClose={handleCloseModal}
+        issueId={selectedIssueId}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 개요
- DB 개인정보 이슈 화면 API 연동

## 변경사항
- features/db-pii: 이슈 API 타입·함수 추가
  - getDbPiiIssues, getDbPiiIssueDetail, patchDbPiiIssueStatus
- db-privacy-issues/Page.tsx: Mock 제거, 목록·통계·페이지네이션(더보기) 연동
- db-privacy-issues/IssueDetailModal.tsx: 상세 조회, 작업 상태 변경 연동
- db-privacy-issues/lib/format.ts: formatDetectedAt 추가
- 백엔드 미구현 시 "No static resource" 응답 시 빈 목록 + 안내 문구 처리
- 응답 파싱 보강: result.content가 배열/{ content: [] } 둘 다 지원
- IssueDetailModal effect 내 동기 setState 제거 → setTimeout(0)로 지연 후 setState (캐스케이딩 렌더 경고 해결)

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 **To Reviewers**

<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * DB 개인정보 이슈 조회·상세·상태갱신 API 추가
  * 이슈 상세 모달의 API 기반 데이터 로드 및 비공개 데이터 테이블 표시
  * 감지 시간 포맷팅 유틸리티 추가

* **개선사항**
  * 정적 데이터 제거 및 전체 화면 API 기반 전환
  * 페이징 및 더보기 로드, 로딩·오류 상태 처리 강화
  * 상태 변경 시 진행 표시와 낙관적 UI 갱신 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->