### PR TITLE
[Feat] #52 DB 수동 스캔

### DIFF
--- a/src/features/db-connection/api/db-connection-api.ts
+++ b/src/features/db-connection/api/db-connection-api.ts
@@ -7,6 +7,7 @@ import type {
   DbConnectionDetailItem,
   DbConnectionListResponse,
   DbConnectionStatsResponse,
+  DbConnectionScanResult,
   ApiResponse,
 } from "./types";
 
@@ -188,5 +189,30 @@ export async function getDbConnectionStats(): Promise<
     return data;
   } catch (e) {
     return toErrorResponse<DbConnectionStatsResponse>(e);
+  }
+}
+
+/** 3-1. DB 수동 스캔 */
+export async function scanDbConnection(
+  connectionId: number,
+): Promise<ApiResponse<DbConnectionScanResult>> {
+  try {
+    const res = await fetchWithAuth(`${BASE}/${connectionId}/scan`, {
+      method: "POST",
+    });
+    const data = (await res
+      .json()
+      .catch(() => ({}))) as ApiResponse<DbConnectionScanResult>;
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<DbConnectionScanResult>(e);
   }
 }

--- a/src/features/db-connection/api/types.ts
+++ b/src/features/db-connection/api/types.ts
@@ -80,6 +80,18 @@ export interface DbConnectionStatsResponse {
   totalColumns: number;
 }
 
+/** 3-1. DB 수동 스캔 응답 */
+export interface DbConnectionScanResult {
+  scanHistoryId: number;
+  connectionId: number;
+  status: "COMPLETED" | "IN_PROGRESS";
+  scanStartTime: string;
+  scanEndTime: string;
+  totalTablesCount: number;
+  totalColumnsCount: number;
+  scannedColumnsCount: number;
+}
+
 /** API 공통 응답 래퍼 */
 export interface ApiResponse<T> {
   success: boolean;

--- a/src/views/db-connection/ui/Page.tsx
+++ b/src/views/db-connection/ui/Page.tsx
@@ -396,7 +396,10 @@ export default function DbConnectionPage() {
 
   const handleScan = async (id: string) => {
     const connectionId = Number(id);
-    if (scanningConnectionId != null) return;
+    if (scanningConnectionId != null) {
+      alert("다른 스캔이 진행 중입니다. 완료 후 다시 시도해 주세요.");
+      return;
+    }
     setScanningConnectionId(connectionId);
     try {
       const res = await scanDbConnection(connectionId);
@@ -559,7 +562,7 @@ export default function DbConnectionPage() {
                 {
                   label: isScanning ? "스캔 중…" : "스캔",
                   variant: "scan",
-                  onClick: () => handleScan(String(item.id)),
+                  onClick: isScanning ? undefined : () => handleScan(String(item.id)),
                 },
                 {
                   label: "수정",

--- a/src/views/db-connection/ui/Page.tsx
+++ b/src/views/db-connection/ui/Page.tsx
@@ -24,6 +24,7 @@ import {
   createDbConnection,
   updateDbConnection,
   deleteDbConnection,
+  scanDbConnection,
 } from "@/features/db-connection";
 import type { DbmsTypeId } from "@/features/db-connection";
 import type {
@@ -177,6 +178,9 @@ export default function DbConnectionPage() {
   const [fieldErrors, setFieldErrors] = useState<
     Partial<Record<keyof ConnectionFormData, string>>
   >({});
+  const [scanningConnectionId, setScanningConnectionId] = useState<
+    number | null
+  >(null);
 
   const loadListAndStats = useCallback(async () => {
     setLoading(true);
@@ -390,10 +394,36 @@ export default function DbConnectionPage() {
     }
   };
 
-  const handleScan = (id: string) => {
-    void id;
-    alert("스캔 기능은 준비 중입니다.");
-    // TODO: DB 스캔 API 연동 (POST /api/db-connections/{connectionId}/scan)
+  const handleScan = async (id: string) => {
+    const connectionId = Number(id);
+    if (scanningConnectionId != null) return;
+    setScanningConnectionId(connectionId);
+    try {
+      const res = await scanDbConnection(connectionId);
+      if (res.success && res.result) {
+        const r = res.result;
+        alert(
+          `스캔이 완료되었습니다.\n테이블 ${r.totalTablesCount}개, 컬럼 ${r.totalColumnsCount}개 중 PII 컬럼 ${r.scannedColumnsCount}개 식별`,
+        );
+        loadListAndStats();
+      } else {
+        const msg = res.message ?? "";
+        const code = res.code ?? "";
+        const isNotConnected =
+          code === "CONNECTION_NOT_CONNECTED" ||
+          code === "DBSCAN4001" ||
+          /연결되지 않은|CONNECTION_NOT_CONNECTED/i.test(msg);
+        alert(
+          isNotConnected
+            ? "연결됨 상태인 DB에서만 스캔할 수 있습니다. 연결 상태를 확인해 주세요."
+            : msg || "스캔에 실패했습니다.",
+        );
+      }
+    } catch {
+      alert("스캔 요청 중 오류가 발생했습니다.");
+    } finally {
+      setScanningConnectionId(null);
+    }
   };
 
   if (loading) {
@@ -519,6 +549,7 @@ export default function DbConnectionPage() {
                   highlight: true,
                 },
               ];
+              const isScanning = scanningConnectionId === item.id;
               const actions: ConnectionActionItem[] = [
                 {
                   label: "상세보기",
@@ -526,7 +557,7 @@ export default function DbConnectionPage() {
                   onClick: () => openViewModal(String(item.id)),
                 },
                 {
-                  label: "스캔",
+                  label: isScanning ? "스캔 중…" : "스캔",
                   variant: "scan",
                   onClick: () => handleScan(String(item.id)),
                 },


### PR DESCRIPTION
## 개요

DB 연결 관리 화면에서 DB 수동 스캔 API 연동

## 변경사항
- features/db-connection
  - DbConnectionScanResult 타입 추가
  - scanDbConnection(connectionId) 추가 — POST /api/db-connections/{connectionId}/scan
- views/db-connection
  - 스캔 버튼 클릭 시 scanDbConnection 호출 (기존 "스캔 기능은 준비 중입니다" 제거)
  - scanningConnectionId 상태로 스캔 중 "스캔 중…" 표시
  - 성공 시 결과 알림 후 목록·통계 갱신 (loadListAndStats)
  - 실패 시 CONNECTION_NOT_CONNECTED / DBSCAN4001 등이면 "연결됨 상태인 DB에서만 스캔할 수 있습니다. 연결 상태를 확인해 주세요." 안내
 
## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 **To Reviewers**

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 데이터베이스 연결 스캔 기능 추가 — 개별 연결을 즉시 스캔하고 테이블/열 수와 스캔 결과를 확인할 수 있습니다.
  * 스캔 진행 상태 표시 — 스캔 중인 연결에 대해 목록에서 "스캔 중…" 라벨을 표시합니다.

* **버그 수정 / 개선**
  * 스캔 실패 시 사용자 친화적 오류 안내 및 스캔 후 목록·통계 자동 갱신 보장.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->