### PR TITLE
[Feat] #57 파일 서버 개인정보 관리 - 개인정보 목록 API 연동

### DIFF
--- a/src/features/file-pii/api/file-pii-api.ts
+++ b/src/features/file-pii/api/file-pii-api.ts
@@ -1,0 +1,102 @@
+import { API_BASE_URL, getApiErrorMessage } from "@/shared/lib/api";
+import { fetchWithAuth } from "@/features/auth/model/api-client";
+import type {
+  FilePiiConnection,
+  FilePiiFilesResult,
+  GetFilePiiFilesParams,
+  ApiResponse,
+} from "./types";
+
+const BASE = `${API_BASE_URL}/api/file-pii`;
+
+const EMPTY_API_RESPONSE: ApiResponse<never> = {
+  success: false,
+  code: "",
+  message: "응답이 비어있습니다.",
+  result: null,
+  timestamp: "",
+};
+
+function errorMessage(
+  data: { message?: string } | null,
+  status: number,
+): string {
+  return data?.message ?? `요청 실패 (${status})`;
+}
+
+function toErrorResponse<T>(error: unknown): ApiResponse<T> {
+  return {
+    ...EMPTY_API_RESPONSE,
+    message: getApiErrorMessage(error),
+  };
+}
+
+function parseJsonResponse<T>(raw: string | null): ApiResponse<T> {
+  if (!raw?.trim()) return { ...EMPTY_API_RESPONSE } as ApiResponse<T>;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object"
+      ? ({ ...EMPTY_API_RESPONSE, ...parsed } as ApiResponse<T>)
+      : ({ ...EMPTY_API_RESPONSE } as ApiResponse<T>);
+  } catch {
+    return {
+      ...EMPTY_API_RESPONSE,
+      message: raw || EMPTY_API_RESPONSE.message,
+    } as ApiResponse<T>;
+  }
+}
+
+/** 9-1. 파일 PII 커넥션 목록 조회 (필터용) */
+export async function getFilePiiConnections(): Promise<
+  ApiResponse<FilePiiConnection[]>
+> {
+  try {
+    const res = await fetchWithAuth(`${BASE}/connections`);
+    const raw = await res.text().catch(() => "");
+    const data = parseJsonResponse<FilePiiConnection[]>(raw || null);
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<FilePiiConnection[]>(e);
+  }
+}
+
+/** 9-2. 파일 PII 목록·통계 조회 */
+export async function getFilePiiFiles(
+  params?: GetFilePiiFilesParams,
+): Promise<ApiResponse<FilePiiFilesResult>> {
+  try {
+    const search = new URLSearchParams();
+    if (params?.connectionId != null)
+      search.set("connectionId", String(params.connectionId));
+    if (params?.category != null) search.set("category", params.category);
+    if (params?.masked != null) search.set("masked", String(params.masked));
+    if (params?.riskLevel != null) search.set("riskLevel", params.riskLevel);
+    if (params?.keyword != null) search.set("keyword", params.keyword);
+    if (params?.page != null) search.set("page", String(params.page));
+    if (params?.size != null) search.set("size", String(params.size));
+    const qs = search.toString();
+    const url = qs ? `${BASE}/files?${qs}` : `${BASE}/files`;
+    const res = await fetchWithAuth(url);
+    const raw = await res.text().catch(() => "");
+    const data = parseJsonResponse<FilePiiFilesResult>(raw || null);
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<FilePiiFilesResult>(e);
+  }
+}

--- a/src/features/file-pii/api/index.ts
+++ b/src/features/file-pii/api/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./file-pii-api";

--- a/src/features/file-pii/api/types.ts
+++ b/src/features/file-pii/api/types.ts
@@ -1,0 +1,64 @@
+/** 9-1. 파일 PII 커넥션 한 건 */
+export interface FilePiiConnection {
+  id: number;
+  connectionName: string;
+  serverTypeName: string;
+}
+
+/** 9-2. 파일 PII 한 건 */
+export interface FilePiiFile {
+  fileId: number;
+  connectionName: string;
+  serverTypeName: string;
+  fileName: string;
+  filePath: string;
+  fileCategory: "DOCUMENT" | "PHOTO" | "VIDEO" | "AUDIO";
+  fileCategoryName: string;
+  masked: boolean;
+  riskLevel: "HIGH" | "MEDIUM" | "LOW";
+  lastScannedAt: string;
+}
+
+/** 9-2. 파일 목록 응답 stats */
+export interface FilePiiFilesStats {
+  totalFiles: number;
+  highRiskCount: number;
+  maskingRate: number;
+  totalFileSize: number;
+}
+
+/** 9-2. Slice 페이지 content */
+export interface FilePiiFilesContent {
+  content: FilePiiFile[];
+  pageable: { pageNumber: number; pageSize: number };
+  first: boolean;
+  last: boolean;
+  hasNext: boolean;
+  numberOfElements: number;
+}
+
+/** 9-2. 파일 목록 응답 result */
+export interface FilePiiFilesResult {
+  stats: FilePiiFilesStats;
+  content: FilePiiFilesContent;
+}
+
+/** 9-2. 쿼리 파라미터 */
+export interface GetFilePiiFilesParams {
+  connectionId?: number;
+  category?: "DOCUMENT" | "PHOTO" | "VIDEO" | "AUDIO";
+  masked?: boolean;
+  riskLevel?: "HIGH" | "MEDIUM" | "LOW";
+  keyword?: string;
+  page?: number;
+  size?: number;
+}
+
+/** API 공통 응답 래퍼 */
+export interface ApiResponse<T> {
+  success: boolean;
+  code: string;
+  message: string;
+  result: T | null;
+  timestamp: string;
+}

--- a/src/features/file-pii/index.ts
+++ b/src/features/file-pii/index.ts
@@ -1,0 +1,1 @@
+export * from "./api";

--- a/src/views/file-privacy-list/lib/format.ts
+++ b/src/views/file-privacy-list/lib/format.ts
@@ -1,0 +1,30 @@
+/** API lastScannedAt ISO 문자열 → 스캔일시 표시 (YYYY.MM.DD HH:mm) */
+export function formatScanDateTime(isoString: string): string {
+  if (!isoString || typeof isoString !== "string") return "";
+  try {
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) return isoString;
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, "0");
+    const d = String(date.getDate()).padStart(2, "0");
+    const h = String(date.getHours()).padStart(2, "0");
+    const min = String(date.getMinutes()).padStart(2, "0");
+    return `${y}.${m}.${d} ${h}:${min}`;
+  } catch {
+    return isoString;
+  }
+}
+
+/** 파일 크기(bytes) → GB/TB 표시 */
+export function formatFileSize(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024 * 1024 * 1024)).toFixed(1)} TB`;
+  }
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${bytes} B`;
+}

--- a/src/views/file-privacy-list/ui/Page.tsx
+++ b/src/views/file-privacy-list/ui/Page.tsx
@@ -193,6 +193,7 @@ export default function FilePrivacyListPage() {
 
   useEffect(() => {
     const id = setTimeout(() => {
+      setPage(0);
       setLoading(true);
       loadFiles(0, false).finally(() => setLoading(false));
     }, 0);

--- a/src/views/file-privacy-list/ui/Page.tsx
+++ b/src/views/file-privacy-list/ui/Page.tsx
@@ -1,16 +1,38 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Database, AlertTriangle, Lock, FileText } from "lucide-react";
-import { StatCard, Table } from "@/shared/ui";
+import { StatCard, Table, Button } from "@/shared/ui";
 import type { TableColumn } from "@/shared/ui";
 import { cn } from "@/shared/lib/utils";
 import FilterSection from "./FilterSection";
+import {
+  getFilePiiConnections,
+  getFilePiiFiles,
+} from "@/features/file-pii";
+import type { FilePiiConnection, FilePiiFile } from "@/features/file-pii";
+import { formatScanDateTime, formatFileSize } from "../lib/format";
 
 type MaskingStatus = "원본" | "마스킹됨";
 type RiskLevel = "높음" | "중간" | "낮음";
 
-interface FilePrivacyItem extends Record<string, unknown> {
+/** API riskLevel → UI 한글 */
+const riskLevelToLabel: Record<string, RiskLevel> = {
+  HIGH: "높음",
+  MEDIUM: "중간",
+  LOW: "낮음",
+};
+
+/** API fileCategory → UI 한글 */
+const categoryToLabel: Record<string, string> = {
+  DOCUMENT: "문서",
+  PHOTO: "사진",
+  VIDEO: "영상",
+  AUDIO: "음성",
+};
+
+/** 테이블 행용 (API 파일 → UI) */
+interface TableRow extends Record<string, unknown> {
   id: string;
   fileServerConnection: string;
   fileName: string;
@@ -19,79 +41,43 @@ interface FilePrivacyItem extends Record<string, unknown> {
   maskingStatus: MaskingStatus;
   riskLevel: RiskLevel;
   scanDateTime: string;
-  fileSizeGb: number;
 }
 
-function formatFileSizeFromGb(sizeGb: number): string {
-  if (sizeGb >= 1000) return `${(sizeGb / 1000).toFixed(1)} TB`;
-  if (sizeGb >= 1) return `${sizeGb.toFixed(1)} GB`;
-  return `${Math.round(sizeGb * 1024)} MB`;
+function fileToRow(f: FilePiiFile): TableRow {
+  return {
+    id: String(f.fileId),
+    fileServerConnection: `${f.connectionName} (${f.serverTypeName})`,
+    fileName: f.fileName,
+    filePath: f.filePath,
+    fileType: categoryToLabel[f.fileCategory] ?? f.fileCategoryName,
+    maskingStatus: f.masked ? "마스킹됨" : "원본",
+    riskLevel: riskLevelToLabel[f.riskLevel] ?? "낮음",
+    scanDateTime: formatScanDateTime(f.lastScannedAt),
+  };
 }
 
-function generateMockItems(): FilePrivacyItem[] {
-  const items: FilePrivacyItem[] = [];
-  const connections = ["S3 Document Storage", "Legacy NAS Share", "NFS Backup"];
-  const fileTypes = ["문서", "사진", "영상", "음성"];
-  const riskLevels: RiskLevel[] = ["낮음", "중간", "높음"];
-  const maskingStatuses: MaskingStatus[] = ["원본", "마스킹됨"];
-  const fileNames = [
-    "user_guide.txt",
-    "reservation_info.txt",
-    "profile_photo.png",
-    "user_list.csv",
-    "payment_capture.png",
-    "reservation_ticket.pdf",
-    "facility_manual.pdf",
-    "id_scan.png",
-    "ticket_image.png",
-    "facility_notice.wav",
-    "notice_content.docs",
-    "reservation.mp4",
-  ];
-  const paths = [
-    "desktop/user/add",
-    "desktop/reservation/detail",
-    "desktop/user/list",
-    "desktop/payment/add",
-    "desktop/facility/manage",
-    "desktop/notice/list",
-    "desktop/reservation/list",
-    "desktop/user/detail",
-  ];
+/** 파일 카테고리 필터 옵션 */
+const FILE_CATEGORY_OPTIONS = [
+  { value: "all", label: "파일 형식" },
+  { value: "DOCUMENT", label: "문서" },
+  { value: "PHOTO", label: "사진" },
+  { value: "VIDEO", label: "영상" },
+  { value: "AUDIO", label: "음성" },
+];
 
-  for (let i = 1; i <= 120; i++) {
-    const fileName = fileNames[(i - 1) % fileNames.length];
-    const fileType = fileTypes[(i - 1) % fileTypes.length];
-    const riskLevel = riskLevels[(i * 7) % riskLevels.length];
-    const maskingStatus = maskingStatuses[(i * 5) % maskingStatuses.length];
-    const connection = connections[(i - 1) % connections.length];
-    const filePath = paths[(i * 3) % paths.length];
-
-    const hour = String((i * 2) % 24).padStart(2, "0");
-    const minute = String((i * 7) % 60).padStart(2, "0");
-    const day = String(17 + (i % 3)).padStart(2, "0");
-
-    // 대략적인 파일 용량(GB) - deterministic
-    const sizeGb = ((i * 13) % 820) / 10 + 0.2; // 0.2GB ~ 82.1GB
-
-    items.push({
-      id: String(i),
-      fileServerConnection: connection,
-      fileName,
-      filePath,
-      fileType,
-      maskingStatus,
-      riskLevel,
-      scanDateTime: `01/${day} ${hour}:${minute}`,
-      fileSizeGb: sizeGb,
-    });
-  }
-
-  return items;
-}
+const PAGE_SIZE = 20;
 
 export default function FilePrivacyListPage() {
-  const [items] = useState<FilePrivacyItem[]>(generateMockItems());
+  const [connections, setConnections] = useState<FilePiiConnection[]>([]);
+  const [rows, setRows] = useState<TableRow[]>([]);
+  const [stats, setStats] = useState<{
+    totalFiles: number;
+    highRiskCount: number;
+    maskingRate: number;
+    totalFileSize: number;
+  } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const [searchQuery, setSearchQuery] = useState("");
   const [appliedSearchQuery, setAppliedSearchQuery] = useState("");
@@ -99,71 +85,123 @@ export default function FilePrivacyListPage() {
   const [selectedFileType, setSelectedFileType] = useState("all");
   const [selectedMaskingStatus, setSelectedMaskingStatus] = useState("all");
   const [selectedRiskLevel, setSelectedRiskLevel] = useState("all");
+  const [page, setPage] = useState(0);
+  const [hasNext, setHasNext] = useState(false);
 
-  const connectionOptions = useMemo(() => {
-    const unique = Array.from(
-      new Set(items.map((i) => i.fileServerConnection).filter(Boolean)),
-    );
-    return [
-      { value: "all", label: "모든 커넥션" },
-      ...unique.map((v) => ({ value: v, label: v })),
-    ];
-  }, [items]);
+  const connectionOptions = [
+    { value: "all", label: "모든 커넥션" },
+    ...connections.map((c) => ({
+      value: String(c.id),
+      label: `${c.connectionName} (${c.serverTypeName})`,
+    })),
+  ];
 
-  const fileTypeOptions = useMemo(() => {
-    const unique = Array.from(new Set(items.map((i) => i.fileType).filter(Boolean)));
-    return [
-      { value: "all", label: "파일 형식" },
-      ...unique.map((v) => ({ value: v, label: v })),
-    ];
-  }, [items]);
+  const fileTypeOptions = FILE_CATEGORY_OPTIONS;
 
-  const filteredItems = useMemo(() => {
-    const q = appliedSearchQuery.trim().toLowerCase();
-    return items.filter((item) => {
-      if (q) {
-        if (
-          !item.fileName.toLowerCase().includes(q) &&
-          !item.filePath.toLowerCase().includes(q)
-        ) {
-          return false;
+  const loadConnections = useCallback(async () => {
+    const res = await getFilePiiConnections();
+    if (res.success && res.result) {
+      setConnections(res.result);
+    }
+  }, []);
+
+  const loadFiles = useCallback(
+    async (pageNum: number, append: boolean): Promise<boolean> => {
+      const params: {
+        connectionId?: number;
+        category?: "DOCUMENT" | "PHOTO" | "VIDEO" | "AUDIO";
+        masked?: boolean;
+        riskLevel?: "HIGH" | "MEDIUM" | "LOW";
+        keyword?: string;
+        page?: number;
+        size?: number;
+      } = {
+        page: pageNum,
+        size: PAGE_SIZE,
+      };
+      if (selectedConnection !== "all") {
+        params.connectionId = Number(selectedConnection);
+      }
+      if (selectedFileType !== "all") {
+        params.category = selectedFileType as "DOCUMENT" | "PHOTO" | "VIDEO" | "AUDIO";
+      }
+      if (selectedMaskingStatus === "original") {
+        params.masked = false;
+      } else if (selectedMaskingStatus === "masked") {
+        params.masked = true;
+      }
+      if (selectedRiskLevel === "high") {
+        params.riskLevel = "HIGH";
+      } else if (selectedRiskLevel === "medium") {
+        params.riskLevel = "MEDIUM";
+      } else if (selectedRiskLevel === "low") {
+        params.riskLevel = "LOW";
+      }
+      if (appliedSearchQuery.trim()) {
+        params.keyword = appliedSearchQuery.trim();
+      }
+      const res = await getFilePiiFiles(params);
+      if (!res.success) {
+        setError(res.message ?? "파일 목록을 불러오지 못했습니다.");
+        if (!append) setRows([]);
+        setHasNext(false);
+        return false;
+      }
+      setError(null);
+      if (res.result) {
+        const rawContent = res.result.content;
+        const contentArray: FilePiiFile[] = Array.isArray(rawContent)
+          ? rawContent
+          : Array.isArray((rawContent as { content?: FilePiiFile[] })?.content)
+            ? (rawContent as { content: FilePiiFile[] }).content
+            : [];
+        const list = contentArray
+          .filter(
+            (f): f is FilePiiFile =>
+              f != null &&
+              typeof f.fileId === "number" &&
+              typeof f.fileName === "string",
+          )
+          .map(fileToRow);
+        if (append) {
+          setRows((prev) => [...prev, ...list]);
+        } else {
+          setRows(list);
         }
+        setStats(res.result.stats ?? null);
+        const slice =
+          rawContent && !Array.isArray(rawContent)
+            ? (rawContent as { hasNext?: boolean })
+            : null;
+        setHasNext(Boolean(slice?.hasNext));
+        return true;
       }
+      if (!append) setRows([]);
+      setStats(null);
+      setHasNext(false);
+      return false;
+    },
+    [selectedConnection, selectedFileType, selectedMaskingStatus, selectedRiskLevel, appliedSearchQuery],
+  );
 
-      if (selectedConnection !== "all" && item.fileServerConnection !== selectedConnection) {
-        return false;
-      }
-      if (selectedFileType !== "all" && item.fileType !== selectedFileType) {
-        return false;
-      }
-      if (selectedMaskingStatus === "original" && item.maskingStatus !== "원본") {
-        return false;
-      }
-      if (selectedMaskingStatus === "masked" && item.maskingStatus !== "마스킹됨") {
-        return false;
-      }
-      if (selectedRiskLevel === "high" && item.riskLevel !== "높음") {
-        return false;
-      }
-      if (selectedRiskLevel === "medium" && item.riskLevel !== "중간") {
-        return false;
-      }
-      if (selectedRiskLevel === "low" && item.riskLevel !== "낮음") {
-        return false;
-      }
-      return true;
-    });
-  }, [
-    items,
-    appliedSearchQuery,
-    selectedConnection,
-    selectedFileType,
-    selectedMaskingStatus,
-    selectedRiskLevel,
-  ]);
+  useEffect(() => {
+    const id = setTimeout(() => {
+      loadConnections();
+    }, 0);
+    return () => clearTimeout(id);
+  }, [loadConnections]);
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setLoading(true);
+      loadFiles(0, false).finally(() => setLoading(false));
+    }, 0);
+    return () => clearTimeout(id);
+  }, [loadFiles]);
 
   const handleSearch = () => {
     setAppliedSearchQuery(searchQuery);
+    setPage(0);
   };
 
   const handleReset = () => {
@@ -173,16 +211,25 @@ export default function FilePrivacyListPage() {
     setSelectedFileType("all");
     setSelectedMaskingStatus("all");
     setSelectedRiskLevel("all");
+    setPage(0);
   };
 
-  // 통계(전체 기준)
-  const totalFiles = items.length;
-  const highRiskItems = items.filter((i) => i.riskLevel === "높음").length;
-  const maskedItems = items.filter((i) => i.maskingStatus === "마스킹됨").length;
-  const maskingRate = totalFiles === 0 ? 0 : Math.round((maskedItems / totalFiles) * 100);
-  const totalSizeGb = items.reduce((sum, i) => sum + i.fileSizeGb, 0);
+  const handleLoadMore = () => {
+    const nextPage = page + 1;
+    setLoading(true);
+    loadFiles(nextPage, true)
+      .then((ok) => {
+        if (ok) setPage(nextPage);
+      })
+      .finally(() => setLoading(false));
+  };
 
-  const columns: TableColumn<FilePrivacyItem>[] = [
+  const totalFiles = stats?.totalFiles ?? 0;
+  const highRiskItems = stats?.highRiskCount ?? 0;
+  const maskingRate = stats?.maskingRate ?? 0;
+  const totalFileSize = stats?.totalFileSize ?? 0;
+
+  const columns: TableColumn<TableRow>[] = [
     { id: "fileServerConnection", label: "파일 서버 연결", width: "2fr" },
     { id: "fileName", label: "파일명", width: "1.5fr" },
     { id: "filePath", label: "파일 경로", width: "2fr" },
@@ -245,14 +292,14 @@ export default function FilePrivacyListPage() {
           colorScheme="coral"
         />
         <StatCard
-          title="암호화율"
-          value={`${maskingRate}%`}
+          title="마스킹율"
+          value={`${maskingRate.toFixed(1)}%`}
           icon={<Lock className="size-5" />}
           colorScheme="purple"
         />
         <StatCard
           title="개인정보 파일 용량"
-          value={formatFileSizeFromGb(totalSizeGb)}
+          value={formatFileSize(totalFileSize)}
           icon={<Database className="size-5" />}
           colorScheme="green"
         />
@@ -277,13 +324,45 @@ export default function FilePrivacyListPage() {
         />
 
         <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-          <Table
-            columns={columns}
-            data={filteredItems}
-            scrollable
-            maxBodyHeight="100%"
-            className="h-full"
-          />
+          {loading && rows.length === 0 ? (
+            <div className="flex-1 flex items-center justify-center text-white">
+              <div
+                className="size-10 rounded-full border-2 border-[var(--color-main-bg)] border-t-transparent animate-spin"
+                aria-label="로딩 중"
+              />
+            </div>
+          ) : error && rows.length === 0 ? (
+            <div className="flex-1 flex items-center justify-center text-white">
+              <p className="text-[var(--color-coral-text)]">{error}</p>
+            </div>
+          ) : rows.length === 0 ? (
+            <div className="flex-1 flex items-center justify-center text-white/70">
+              파일이 없습니다.
+            </div>
+          ) : (
+            <>
+              <Table
+                columns={columns}
+                data={rows}
+                scrollable
+                maxBodyHeight="100%"
+                className="h-full"
+              />
+              {hasNext && (
+                <div className="shrink-0 pt-3 flex justify-center pb-2">
+                  <Button
+                    type="button"
+                    onClick={handleLoadMore}
+                    disabled={loading}
+                    colorScheme="main"
+                    appearance="outline"
+                  >
+                    {loading ? "로딩 중..." : "더보기"}
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/views/file-privacy-list/ui/Page.tsx
+++ b/src/views/file-privacy-list/ui/Page.tsx
@@ -51,7 +51,7 @@ function fileToRow(f: FilePiiFile): TableRow {
     filePath: f.filePath,
     fileType: categoryToLabel[f.fileCategory] ?? f.fileCategoryName,
     maskingStatus: f.masked ? "마스킹됨" : "원본",
-    riskLevel: riskLevelToLabel[f.riskLevel] ?? "낮음",
+    riskLevel: riskLevelToLabel[f.riskLevel] ?? "높음",
     scanDateTime: formatScanDateTime(f.lastScannedAt),
   };
 }
@@ -99,9 +99,15 @@ export default function FilePrivacyListPage() {
   const fileTypeOptions = FILE_CATEGORY_OPTIONS;
 
   const loadConnections = useCallback(async () => {
-    const res = await getFilePiiConnections();
-    if (res.success && res.result) {
-      setConnections(res.result);
+    try {
+      const res = await getFilePiiConnections();
+      if (res.success && res.result) {
+        setConnections(res.result);
+      } else {
+        console.error("커넥션 목록 로드 실패:", res.message);
+      }
+    } catch (err) {
+      console.error("커넥션 API 호출 오류:", err);
     }
   }, []);
 


### PR DESCRIPTION
## 개요

- 파일 서버 개인정보 목록 화면에서 파일 PII API 연동


## 변경사항

- features/file-pii (신규)
  - GET /api/file-pii/connections (필터 드롭다운용)
  - GET /api/file-pii/files (목록·통계, 필터: connectionId, category, masked, riskLevel, keyword)
  - 타입: FilePiiConnection, FilePiiFile, FilePiiFilesStats, FilePiiFilesResult 등
- views/file-privacy-list
  - Mock 데이터 제거 (generateMockItems 삭제)
  - API로 커넥션 옵션 로드, 목록·통계 조회
  - 필터(커넥션/파일 형식/마스킹 상태/위험도/검색) → API 파라미터로 전달
  - 페이지네이션(더보기) 구현
  - 통계 카드: 총 파일, 고위험 항목, 마스킹율, 파일 용량
  - views/file-privacy-list/lib/format.ts (신규)
  - formatScanDateTime, formatFileSize 추가
 
## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 **To Reviewers**

<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 파일 개인정보 목록을 실제 API로 로드하도록 전면 전환
  * 연결 목록 자동로드 및 연결·카테고리·마스킹·위험 수준·키워드 필터 지원
  * 페이지네이션 및 "더보기"로 추가 항목 로드, 검색·초기화 동작 개선
  * 로딩 스켈레톤, 오류 메시지 및 빈 상태 표시 개선
  * 실시간 통계 카드(총 파일·고위험·마스킹율·용량) 업데이트
  * 날짜 및 파일 크기 표시 형식 개선, UI용 라벨 매핑 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->