### PR TITLE
[Feat] #79 알림 시스템 API 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -266,6 +265,7 @@
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2865,6 +2865,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2885,6 +2886,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2946,7 +2948,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3052,7 +3055,6 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3063,7 +3065,6 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3130,7 +3131,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -3630,7 +3630,6 @@
       "integrity": "sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/mocker": "4.0.18",
         "@vitest/utils": "4.0.18",
@@ -3654,7 +3653,6 @@
       "integrity": "sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -3909,7 +3907,6 @@
       "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "pathe": "^2.0.3"
@@ -3966,7 +3963,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4315,7 +4311,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -4380,7 +4375,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4530,7 +4524,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -4843,6 +4836,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4875,7 +4869,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5128,7 +5123,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5193,7 +5187,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5379,7 +5372,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7317,6 +7309,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7952,7 +7945,6 @@
       "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.58.0"
       },
@@ -8044,6 +8036,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8059,6 +8052,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8071,7 +8065,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8121,7 +8116,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8186,7 +8180,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8347,7 +8340,6 @@
       "integrity": "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8796,7 +8788,6 @@
       "integrity": "sha512-fIQnFtpksRRgHR1CO1onGX3djaog4qsW/c5U8arqYTkUEr2TaWpn05mIJDOBoPJFlOdqFrB4Ttv0PZJxV7avhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -9231,7 +9222,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9465,7 +9455,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9645,7 +9634,6 @@
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -9656,7 +9644,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9812,7 +9799,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9826,7 +9812,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -10275,7 +10260,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/features/notification/api/index.ts
+++ b/src/features/notification/api/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./notification-api";

--- a/src/features/notification/api/notification-api.ts
+++ b/src/features/notification/api/notification-api.ts
@@ -26,6 +26,20 @@ function toErrorResponse<T>(error: unknown): ApiResponse<T> {
   };
 }
 
+/** 응답 정규화: 빈 바디(204) 등에서 최소 필드 보장 */
+function normalizeApiResponse<T>(
+  data: Partial<ApiResponse<T>>,
+  defaultResult: T | null = null,
+): ApiResponse<T> {
+  return {
+    success: data.success ?? true,
+    code: data.code ?? "COMMON200",
+    message: data.message ?? "요청이 성공했습니다.",
+    result: data.result !== undefined ? data.result : defaultResult,
+    timestamp: data.timestamp ?? new Date().toISOString(),
+  };
+}
+
 /** 알림 목록 조회 (페이지네이션) */
 export async function getNotificationList(params?: {
   page?: number;
@@ -49,7 +63,7 @@ export async function getNotificationList(params?: {
         result: null,
       };
     }
-    return data;
+    return normalizeApiResponse(data, null);
   } catch (e) {
     return toErrorResponse<NotificationListResponse>(e);
   }
@@ -72,7 +86,7 @@ export async function getRecentUnreadNotifications(): Promise<
         result: null,
       };
     }
-    return data;
+    return normalizeApiResponse(data, []);
   } catch (e) {
     return toErrorResponse<NotificationItem[]>(e);
   }
@@ -95,7 +109,7 @@ export async function getUnreadCount(): Promise<
         result: null,
       };
     }
-    return data;
+    return normalizeApiResponse(data, { unreadCount: 0 });
   } catch (e) {
     return toErrorResponse<NotificationStatsResponse>(e);
   }
@@ -120,7 +134,7 @@ export async function markNotificationAsRead(
         result: null,
       };
     }
-    return data;
+    return normalizeApiResponse(data, null);
   } catch (e) {
     return toErrorResponse<NotificationItem>(e);
   }

--- a/src/features/notification/api/notification-api.ts
+++ b/src/features/notification/api/notification-api.ts
@@ -1,0 +1,127 @@
+import { API_BASE_URL, getApiErrorMessage } from "@/shared/lib/api";
+import { fetchWithAuth } from "@/features/auth/model/api-client";
+import type {
+  NotificationListResponse,
+  NotificationItem,
+  NotificationStatsResponse,
+  ApiResponse,
+} from "./types";
+
+const BASE = `${API_BASE_URL}/api/notifications`;
+
+function errorMessage(
+  data: { message?: string } | null,
+  status: number,
+): string {
+  return data?.message ?? `요청 실패 (${status})`;
+}
+
+function toErrorResponse<T>(error: unknown): ApiResponse<T> {
+  return {
+    success: false,
+    code: "",
+    message: getApiErrorMessage(error),
+    result: null,
+    timestamp: "",
+  };
+}
+
+/** 알림 목록 조회 (페이지네이션) */
+export async function getNotificationList(params?: {
+  page?: number;
+  size?: number;
+}): Promise<ApiResponse<NotificationListResponse>> {
+  try {
+    const search = new URLSearchParams();
+    if (params?.page != null) search.set("page", String(params.page));
+    if (params?.size != null) search.set("size", String(params.size));
+    const qs = search.toString();
+    const url = qs ? `${BASE}?${qs}` : BASE;
+    const res = await fetchWithAuth(url);
+    const data = (await res
+      .json()
+      .catch(() => ({}))) as ApiResponse<NotificationListResponse>;
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<NotificationListResponse>(e);
+  }
+}
+
+/** 최근 읽지 않은 알림 조회 (헤더 드롭다운용) */
+export async function getRecentUnreadNotifications(): Promise<
+  ApiResponse<NotificationItem[]>
+> {
+  try {
+    const res = await fetchWithAuth(`${BASE}/recent-unread`);
+    const data = (await res
+      .json()
+      .catch(() => ({}))) as ApiResponse<NotificationItem[]>;
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<NotificationItem[]>(e);
+  }
+}
+
+/** 읽지 않은 알림 개수 조회 */
+export async function getUnreadCount(): Promise<
+  ApiResponse<NotificationStatsResponse>
+> {
+  try {
+    const res = await fetchWithAuth(`${BASE}/unread-count`);
+    const data = (await res
+      .json()
+      .catch(() => ({}))) as ApiResponse<NotificationStatsResponse>;
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<NotificationStatsResponse>(e);
+  }
+}
+
+/** 알림 읽음 처리 */
+export async function markNotificationAsRead(
+  notificationId: number,
+): Promise<ApiResponse<NotificationItem>> {
+  try {
+    const res = await fetchWithAuth(`${BASE}/${notificationId}/read`, {
+      method: "PATCH",
+    });
+    const data = (await res
+      .json()
+      .catch(() => ({}))) as ApiResponse<NotificationItem>;
+    if (!res.ok) {
+      return {
+        ...data,
+        success: false,
+        message: errorMessage(data, res.status),
+        result: null,
+      };
+    }
+    return data;
+  } catch (e) {
+    return toErrorResponse<NotificationItem>(e);
+  }
+}

--- a/src/features/notification/api/types.ts
+++ b/src/features/notification/api/types.ts
@@ -1,0 +1,52 @@
+/** 알림 유형 */
+export type NotificationType =
+  | "FILE_ISSUE_DETECTED"
+  | "DB_ISSUE_DETECTED"
+  | "FILE_SCAN_COMPLETED"
+  | "DB_SCAN_COMPLETED"
+  | "MASKING_COMPLETED";
+
+/** 엔티티 타입 */
+export type EntityType =
+  | "DB_PII_ISSUE"
+  | "FILE_PII_ISSUE"
+  | "DB_SCAN_HISTORY"
+  | "FILE_SCAN_HISTORY"
+  | "MASKING_LOG";
+
+/** 단일 알림 항목 */
+export interface NotificationItem {
+  id: number;
+  type: NotificationType;
+  title: string;
+  message: string;
+  entityType: EntityType | null;
+  entityId: number | null;
+  isRead: boolean;
+  issuedAt: string;
+  readAt: string | null;
+}
+
+/** 알림 목록 응답 (Slice 페이지네이션) */
+export interface NotificationListResponse {
+  content: NotificationItem[];
+  pageable: { pageNumber: number; pageSize: number };
+  first: boolean;
+  last: boolean;
+  hasNext: boolean;
+  numberOfElements: number;
+}
+
+/** 읽지 않은 개수 통계 */
+export interface NotificationStatsResponse {
+  unreadCount: number;
+}
+
+/** API 공통 응답 래퍼 */
+export interface ApiResponse<T> {
+  success: boolean;
+  code: string;
+  message: string;
+  result: T | null;
+  timestamp: string;
+}

--- a/src/features/notification/index.ts
+++ b/src/features/notification/index.ts
@@ -1,0 +1,1 @@
+export * from "./api";

--- a/src/widgets/header/ui/header.tsx
+++ b/src/widgets/header/ui/header.tsx
@@ -3,7 +3,12 @@
 import * as React from "react";
 import { cn } from "@/shared/lib/utils";
 import { Bell } from "lucide-react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import {
+  getRecentUnreadNotifications,
+  markNotificationAsRead,
+  type NotificationItem,
+} from "@/features/notification";
 
 interface HeaderProps {
   className?: string;
@@ -50,12 +55,40 @@ export function Header({
   title,
   pathname: pathnameProp,
 }: HeaderProps) {
+  const router = useRouter();
   const fromRouter = usePathname();
   const pathname =
     pathnameProp !== undefined ? pathnameProp : (fromRouter ?? null);
   const [isNotificationOpen, setIsNotificationOpen] = React.useState(false);
+  const [notifications, setNotifications] = React.useState<NotificationItem[]>(
+    [],
+  );
+  const [hasUnread, setHasUnread] = React.useState(false);
+  const [loading, setLoading] = React.useState(false);
 
   const pageTitle = title || resolvePageTitle(pathname);
+
+  // 드롭다운 열릴 때 데이터 fetch
+  React.useEffect(() => {
+    if (isNotificationOpen && !loading) {
+      fetchNotificationData();
+    }
+  }, [isNotificationOpen]);
+
+  const fetchNotificationData = async () => {
+    setLoading(true);
+    try {
+      const response = await getRecentUnreadNotifications();
+      if (response.success && response.result) {
+        setNotifications(response.result);
+        setHasUnread(response.result.some((n) => !n.isRead));
+      }
+    } catch (error) {
+      console.error("Failed to fetch notifications:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleNotificationClick = () => {
     setIsNotificationOpen((prev) => !prev);
@@ -63,6 +96,45 @@ export function Header({
 
   const handleClickOutside = () => {
     setIsNotificationOpen(false);
+  };
+
+  const handleNotificationItemClick = async (notification: NotificationItem) => {
+    // 읽지 않은 알림이면 읽음 처리
+    if (!notification.isRead) {
+      await markNotificationAsRead(notification.id);
+      // 데이터 재조회
+      fetchNotificationData();
+    }
+
+    // entityType에 따라 이동
+    if (notification.entityType === "DB_PII_ISSUE") {
+      router.push("/privacy/db/issues");
+    } else if (notification.entityType === "FILE_PII_ISSUE") {
+      router.push("/privacy/file/issues");
+    } else if (notification.entityType === "DB_SCAN_HISTORY") {
+      router.push("/privacy/db/list");
+    } else if (notification.entityType === "FILE_SCAN_HISTORY") {
+      router.push("/privacy/file/list");
+    } else if (notification.entityType === "MASKING_LOG") {
+      router.push("/privacy/file/masking");
+    }
+
+    setIsNotificationOpen(false);
+  };
+
+  const formatTimestamp = (dateString: string): string => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+
+    if (diffMins < 1) return "방금 전";
+    if (diffMins < 60) return `${diffMins}분 전`;
+    if (diffHours < 24) return `${diffHours}시간 전`;
+    if (diffDays < 7) return `${diffDays}일 전`;
+    return date.toLocaleDateString("ko-KR");
   };
 
   return (
@@ -92,7 +164,9 @@ export function Header({
           aria-expanded={isNotificationOpen}
         >
           <Bell className="w-5 h-5" />
-          <span className="absolute top-1 right-1 w-2 h-2 bg-[var(--color-coral-text)] rounded-full" />
+          {hasUnread && (
+            <span className="absolute top-1 right-1 w-2 h-2 bg-[var(--color-coral-text)] rounded-full" />
+          )}
         </button>
 
         {isNotificationOpen && (
@@ -101,7 +175,7 @@ export function Header({
             <div
               className={cn(
                 "absolute right-0 top-full mt-2",
-                "w-80 max-h-96",
+                "w-96 max-h-[500px]",
                 "rounded-md border border-[var(--color-content-border)] bg-[var(--color-bg-main)] shadow-lg overflow-y-auto z-20",
               )}
             >
@@ -110,9 +184,53 @@ export function Header({
               </div>
 
               <div className="p-2">
-                <div className="p-3 text-sm text-[#94A3B8] text-center">
-                  새로운 알림이 없습니다
-                </div>
+                {loading ? (
+                  <div className="p-3 text-sm text-[#94A3B8] text-center">
+                    로딩 중...
+                  </div>
+                ) : notifications.length > 0 ? (
+                  <div className="space-y-1">
+                    {notifications.map((notification) => (
+                      <div
+                        key={notification.id}
+                        onClick={() => handleNotificationItemClick(notification)}
+                        className={cn(
+                          "p-3 rounded-md cursor-pointer",
+                          "hover:bg-[var(--color-sidebar-hover-bg)]",
+                          "transition-colors",
+                          !notification.isRead &&
+                            "bg-[var(--color-sidebar-hover-bg)]/50",
+                        )}
+                      >
+                        <div className="flex items-start gap-3">
+                          {!notification.isRead && (
+                            <span className="w-2 h-2 mt-1.5 bg-[var(--color-coral-text)] rounded-full flex-shrink-0" />
+                          )}
+                          <div className="flex-1 min-w-0">
+                            <p
+                              className={cn(
+                                "text-sm text-white truncate",
+                                !notification.isRead && "font-semibold",
+                              )}
+                            >
+                              {notification.title}
+                            </p>
+                            <p className="text-xs text-[#94A3B8] mt-1 line-clamp-2">
+                              {notification.message}
+                            </p>
+                            <p className="text-xs text-[#64748B] mt-2">
+                              {formatTimestamp(notification.issuedAt)}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="p-3 text-sm text-[#94A3B8] text-center">
+                    새로운 알림이 없습니다
+                  </div>
+                )}
               </div>
             </div>
           </>

--- a/src/widgets/header/ui/header.tsx
+++ b/src/widgets/header/ui/header.tsx
@@ -82,9 +82,16 @@ export function Header({
       if (response.success && response.result) {
         setNotifications(response.result);
         setHasUnread(response.result.some((n) => !n.isRead));
+      } else {
+        // API 실패 시 상태 초기화
+        setNotifications([]);
+        setHasUnread(false);
       }
     } catch (error) {
       console.error("Failed to fetch notifications:", error);
+      // 에러 발생 시 상태 초기화
+      setNotifications([]);
+      setHasUnread(false);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## 개요

<!---- 자신이 완료한 이슈를 닫아주세요 -->

- closed #79

Header 우측 상단 알림 아이콘에 실제 API 연동을 추가하여 개인 알림 목록을 표시하도록 구현
사용자가 알림 아이콘을 클릭하면 최근 읽지 않은 알림 3개가 드롭다운으로 표시되며, 알림 클릭 시 읽음 처리 및 해당 페이지로 이동

<!---- Resolves: #(Issue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 문서 수정


## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 **To Reviewers**

<!-- 전달사항 -->
1. Notification API 클라이언트 구현
    - src/features/notification/api/types.ts: 알림 타입 및 인터페이스 정의
    - src/features/notification/api/notification-api.ts: API 함수 구현
    - getRecentUnreadNotifications(): 최근 읽지 않은 알림 3개 조회
    - markNotificationAsRead(): 알림 읽음 처리
    - getUnreadCount(): 읽지 않은 개수 조회

2. Header 컴포넌트 수정
    - src/widgets/header/ui/header.tsx
    - 드롭다운 열릴 때 최근 읽지 않은 알림 자동 조회
    - 읽지 않은 알림이 있을 때만 빨간 배지 표시
    - 알림 클릭 시 읽음 처리 및 entityType에 따라 페이지 이동
    - 상대 시간 표시 (방금 전, N분 전, N시간 전, N일 전)
    - 로딩 상태 및 빈 상태 처리
  
- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 헤더에 알림 드롭다운 추가: 최근 미읽 알림 목록, 로딩/빈 상태 표시 및 외부 클릭 시 닫힘.
  * 알림 클릭 시 해당 알림 자동으로 읽음 처리 및 미읽 카운트 갱신.
  * 미읽 알림에 도트 표시 및 읽음별 시각적 스타일 적용.
  * 알림 항목에서 제목·메시지·시간 확인 가능하며, 알림 유형에 따라 관련 화면으로 이동.
  * 백엔드와의 알림 조회/카운트/읽음 처리 통합 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->